### PR TITLE
ci: implement multi-environment testing workflow

### DIFF
--- a/.github/workflows/release-distribution.yml
+++ b/.github/workflows/release-distribution.yml
@@ -20,11 +20,12 @@ jobs:
 
       - name: Install BATS
         run: |
-          sudo apt-get update
-          sudo apt-get install -y bats
+          sudo apt-get update || exit 1
+          sudo apt-get install -y bats || exit 1
+          bats --version || exit 1
 
       - name: Run unit tests
-        run: bats --recursive tests/unit/
+        run: bats --recursive tests/unit/ || exit 1
 
   full-tests:
     strategy:
@@ -41,14 +42,16 @@ jobs:
       - name: Install BATS
         run: |
           if [ "${{ runner.os }}" == "Linux" ]; then
-            sudo apt-get update
-            sudo apt-get install -y bats
+            sudo apt-get update || exit 1
+            sudo apt-get install -y bats || exit 1
+            bats --version || exit 1
           elif [ "${{ runner.os }}" == "macOS" ]; then
-            brew install bats-core
+            brew install bats-core || exit 1
+            bats --version || exit 1
           fi
 
       - name: Run all tests
-        run: bats --recursive tests/
+        run: bats --recursive tests/ || exit 1
 
   create-distribution:
     needs: [quick-checks, full-tests]
@@ -205,4 +208,3 @@ jobs:
             --repo "${{ github.repository }}"
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -24,13 +24,24 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Cache BATS dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/apt
+            ~/Library/Caches/Homebrew
+          key: ${{ runner.os }}-bats-${{ hashFiles('.github/workflows/test.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-bats-
+
       - name: Install BATS
         run: |
-          sudo apt-get update
-          sudo apt-get install -y bats
+          sudo apt-get update || exit 1
+          sudo apt-get install -y bats || exit 1
+          bats --version || exit 1
 
       - name: Run unit tests
-        run: bats --recursive tests/unit/
+        run: bats --recursive tests/unit/ || exit 1
 
   full-tests:
     if: ${{ github.event.pull_request.draft == false || github.event_name == 'push' }}
@@ -43,15 +54,26 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Cache BATS dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/apt
+            ~/Library/Caches/Homebrew
+          key: ${{ runner.os }}-bats-${{ hashFiles('.github/workflows/test.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-bats-
+
       - name: Install BATS
         run: |
           if [ "${{ runner.os }}" == "Linux" ]; then
-            sudo apt-get update
-            sudo apt-get install -y bats
+            sudo apt-get update || exit 1
+            sudo apt-get install -y bats || exit 1
+            bats --version || exit 1
           elif [ "${{ runner.os }}" == "macOS" ]; then
-            brew install bats-core
+            brew install bats-core || exit 1
+            bats --version || exit 1
           fi
 
       - name: Run all tests
-        run: bats --recursive tests/
-
+        run: bats --recursive tests/ || exit 1


### PR DESCRIPTION
- Add test.yml workflow with quick-checks and full-tests jobs
- Implement Ubuntu + macOS matrix strategy for full tests
- Add concurrency control, path filtering, and draft PR filtering
- Add timeout limits (10min quick-checks, 30min full-tests)
- Integrate test jobs into release-distribution.yml workflow
- Add concurrency control and timeout to release workflow
- Ensure tests must pass before release distribution

Based on admin/planning/ci/multi-environment-testing/WORKFLOW.md specification

## Summary by Sourcery

Implement a multi-environment CI testing workflow and enforce test passes before release distribution

CI:
- Add new test.yml workflow with quick-checks and full-tests jobs triggered on push and pull requests
- Integrate quick-checks and full-tests as prerequisites in release-distribution.yml with added concurrency control and timeouts
- Introduce Ubuntu and macOS matrix strategy for full-tests
- Add concurrency groups, path filters, draft PR filtering, and timeout limits to streamline and limit CI runs