### PR TITLE
feat(agentic-workflow-modernization): Research Family Foundation (Group 1)

### DIFF
--- a/admin/feedback/sourcery/pr86.md
+++ b/admin/feedback/sourcery/pr86.md
@@ -22,8 +22,8 @@ Use this template to assess each comment:
 
 | Comment | Priority | Impact | Effort | Notes |
 |---------|----------|--------|--------|-------|
-| #1 | | | | |
-| #0 | | | | |
+| Overall #1 — Layout detection on unknown repo structure | 🟢 LOW | 🟢 LOW | 🟢 LOW | Already addressed: "Layout detection failure" paragraph (lines 41-44) stops and reports when no known layout matches |
+| Overall #2 — Restate CLI flags as conversational flows | 🟢 LOW | 🟢 LOW | 🟢 LOW | Already addressed: "Natural-language invocation" paragraph (lines 35-39) maps user intent to modes without CLI flags |
 
 ### Priority Levels
 - 🔴 **CRITICAL**: Security, stability, or core functionality issues

--- a/admin/feedback/sourcery/pr86.md
+++ b/admin/feedback/sourcery/pr86.md
@@ -1,0 +1,46 @@
+# Sourcery Review Analysis
+**PR**: #86
+**Repository**: grimm00/dev-infra
+**Generated**: Sat May  2 17:38:41 CDT 2026
+
+---
+
+## Summary
+
+Total Individual Comments: 0 + Overall Comments
+
+## Individual Comments
+
+## Overall Comments
+
+- In `research-setup/SKILL.md`, consider specifying what to do when the repo doesn’t match any of the known research layouts (dev‑infra vs maintainers docs) so the skill errs safely instead of creating a new ad‑hoc structure in an unintended location.
+- Several behaviors in `research-setup` (e.g., `--force`, `--add-topic`, mutually exclusive flags) are described in CLI terms; it may help to restate these as explicit conversational prompts/flows for the agent so callers that aren’t literally a CLI can still drive the correct behavior.
+
+## Priority Matrix Assessment
+
+Use this template to assess each comment:
+
+| Comment | Priority | Impact | Effort | Notes |
+|---------|----------|--------|--------|-------|
+| #1 | | | | |
+| #0 | | | | |
+
+### Priority Levels
+- 🔴 **CRITICAL**: Security, stability, or core functionality issues
+- 🟠 **HIGH**: Bug risks or significant maintainability issues
+- 🟡 **MEDIUM**: Code quality and maintainability improvements
+- 🟢 **LOW**: Nice-to-have improvements
+
+### Impact Levels
+- 🔴 **CRITICAL**: Affects core functionality
+- 🟠 **HIGH**: User-facing or significant changes
+- 🟡 **MEDIUM**: Developer experience improvements
+- 🟢 **LOW**: Minor improvements
+
+### Effort Levels
+- 🟢 **LOW**: Simple, quick changes
+- 🟡 **MEDIUM**: Moderate complexity
+- 🟠 **HIGH**: Complex refactoring
+- 🔴 **VERY_HIGH**: Major rewrites
+
+

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage2/artifacts/research-command-audit.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage2/artifacts/research-command-audit.md
@@ -1,0 +1,124 @@
+# Research Command Audit — Modes, Mapping, and Tier Classification
+
+**Task:** Task 1 of Stage 2, Group 1 (Research Family Foundation)  
+**Date:** 2026-05-02  
+**Source:** `.cursor/commands/research.md` (1,531 lines)  
+**Reference:** Topic 8 (Behavioral Contracts), same tier rubric as [Stage 1 discuss audit](../../../planning/artifacts/discuss-audit.md)
+
+---
+
+## Tier Definitions (from Topic 8, Finding 1)
+
+| Tier | Description | Rubric properties (typical) |
+|------|-------------|----------------------------|
+| **Tier 1** | Precise — outcome-based, testable | Observable, bounded, outcome-framed, delta-only, failure-aware |
+| **Tier 2** | Mixed — directional but incomplete stopping rules | 3–4 properties |
+| **Tier 3** | Vague — unbounded judgment, persona, or unknowable triggers | 0–2 properties |
+
+---
+
+## Modes and Child Skill Mapping
+
+| Mode | Command surface | Planned child skill | Primary command sections |
+|------|----------------|---------------------|--------------------------|
+| **Setup** (default) | `/research [topic] --from-explore \| --from-reflect \| --topic` | **research-setup** | Step-by-Step §1–7 (Identify source → Commit) |
+| **Add topic** | `/research [topic] --add-topic N` | **research-setup** | Add Topic Mode Workflow §1–5 |
+| **Conduct** | `/research [topic] --conduct [--topic-num \| --topic-name]` | **research-conduct** | Conduct Mode Workflow §1–7, Conduct output checklist |
+| **Consolidate** | `/research [topic] --consolidate [--dry-run]` | **research-consolidate** | Consolidate Mode Workflow §1–8 |
+
+**Design note:** Setup and add-topic share the same skill so scaffolding stays one place; add-topic is structurally “late setup” on an existing research directory. Task 6 will confirm whether add-topic ever splits to its own skill.
+
+---
+
+## Behavioral and Judgment-Rich Instructions (by area)
+
+### Cross-cutting / Workflow overview
+
+| ID | Instruction (paraphrase) | Tier | Notes |
+|----|--------------------------|------|-------|
+| K1 | Follow standardized workflow; create documents per topic; extract requirements; consolidate before decisions | **T1** | Outcome sequence is observable |
+| K2 | Sanitize topic name (kebab-case, no spaces) | **T1** | Deterministic rule |
+
+### Setup mode (scaffolding)
+
+| ID | Instruction (paraphrase) | Tier | Notes |
+|----|--------------------------|------|-------|
+| S1 | Resolve input source exactly one of from-explore / from-reflect / direct topic; extract or prompt for topics | **T1–T2** | “Prompt if needed” is bounded by user reply; topic list must be explicit before file creation |
+| S2 | Auto-detect research layout (dev-infra vs template vs project-wide) before paths | **T1** | Observable branch on repo layout |
+| S3 | For `--from-reflect`: extract “Actionable Suggestions” or “Opportunities for Improvement”; convert to topics | **T2** | Depends on reflection structure variance |
+| S4 | Always commit research scaffolding before finishing setup | **T1** | Matches commit discipline in command |
+
+### Add topic mode
+
+| ID | Instruction (paraphrase) | Tier | Notes |
+|----|--------------------------|------|-------|
+| A1 | Validate research dir exists; topic N exists in `research-topics.md`; file missing unless `--force` | **T1** | Error table is explicit |
+| A2 | Scaffold `topic-N-[name].md` from research document template; populate from research-topics fields | **T1** | Procedural |
+| A3 | Update hub README + `research-summary.md` placeholder | **T1** | Procedural |
+
+### Conduct mode
+
+| ID | Instruction (paraphrase) | Tier | Notes |
+|----|--------------------------|------|-------|
+| C1 | Web search **required** for conduct | **T1** | Binary tool-use obligation |
+| C2 | Each finding recorded with source and relevance | **T1** | Observable in doc |
+| C3 | Process all topics or one topic by num/name; **research high-priority topics first** when doing all | **T2** | Priority comes from research doc/exploration but “first” ordering can be fuzzy if priorities tie |
+| C4 | Formulate queries from question, sub-questions, methodology | **T2** | Quality of queries is judgment-heavy |
+| C5 | Update status to complete, goals checked, summary + requirements + hub | **T1** | Procedural |
+
+### Consolidate mode
+
+| ID | Instruction (paraphrase) | Tier | Notes |
+|----|--------------------------|------|-------|
+| G1 | Preconditions: all topics complete (warn + optional continue), `requirements.md` exists | **T1** | Explicit |
+| G2 | Exploration reconciliation: cross-reference themes vs findings; categorize Mandatory vs Recommended | **T2** | Severity table helps but row assignment is judgment |
+| G3 | **STOP and wait** after reconciliation report; user chooses amendments | **T1** | Clear human gate |
+| G4 | Build mental model of requirement lineage across topics | **T3** | “Mental model” not observable; **must become** explicit tables/checklists in skill |
+| G5 | Analyze redundancies, superseded, gaps, stale wording, priorities | **T2** | Categories are procedural; each classification is judgment |
+| G6 | **CRITICAL:** Present consolidation proposal; **STOP** for human approval before apply | **T1** | Clear human gate |
+| G7 | After approval: merge/remove/add/modify/renumber; Draft → Final | **T1** | Procedural |
+
+### Tips / best practices (agent-facing portions)
+
+Lines ~1499–1507 mix user guidance with agent obligations. Agent-facing items:
+
+| ID | Instruction | Tier | Applies to |
+|----|---------------|------|------------|
+| T1 | Document sources for every finding | **T1** | conduct |
+| T2 | Use web search (required in conduct) | **T1** | conduct |
+| T3 | Extract requirements as you research | **T1** | conduct |
+| T4 | Keep research summary current after each topic | **T1** | conduct |
+| T5 | Consolidate before deciding | **T1** | workflow ordering |
+
+---
+
+## Summary Counts (behavioral / judgment rows above)
+
+| Tier | Approx. count | Notes |
+|------|----------------|-------|
+| **Tier 1** | 22 | Gates, commits, web search requirement, structured updates |
+| **Tier 2** | 7 | Reflection parsing, query formulation, consolidation classification, priority ordering |
+| **Tier 3** | 1 | “Build a mental model” — rewrite during **research-consolidate** conversion |
+
+---
+
+## Content Classification for Skill Conversion (preview)
+
+| Block | Destination skill | Notes |
+|-------|------------------|-------|
+| Setup steps 1–7 + templates | **research-setup** | Procedural + scaffolding |
+| Add topic workflow | **research-setup** | Procedural |
+| Conduct workflow | **research-conduct** | Hybrid procedural + behavioral (Tier 2 areas need rubric passes) |
+| Consolidate workflow | **research-consolidate** | Hybrid; human gates stay Tier 1; analysis steps need tighter bounded procedures |
+| Tips / Integration / Reference | Parent **research** + child intros | Orientation only; parent has no procedural steps |
+
+---
+
+## Documented inconsistencies (for later cleanup, out of Group 1 scope)
+
+- Exploration paths: command “Configuration” vs “Step 1” vs explore family paths differ for dev-infra and template layouts. **research** parent aligns with **explore** path detection; skills should not introduce a fourth variant.
+- Per-topic filenames: Setup uses `research-[question-name].md`; add-topic uses `topic-N-[name].md`. Both must remain documented until a naming ADR unifies them.
+
+---
+
+**Last Updated:** 2026-05-02

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage2/implementation-plan.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage2/implementation-plan.md
@@ -21,7 +21,7 @@ tasks_files:
 ---
 # Implementation Plan — Stage 2: Researcher (Agentic Workflow Modernization)
 
-**Status:** 🔴 Not Started
+**Status:** 🟠 In Progress
 **Created:** 2026-05-02
 **Last Updated:** 2026-05-02
 **Source:** [ADRs 1-5 + design.md Section 5](../decisions/) → Stage 2 of 4-stage v1
@@ -56,9 +56,9 @@ Convert the **Researcher** role group of dev-infra commands to skills. This stag
 ## 📝 Implementation Plan
 
 ### Research Family Foundation
-- [ ] Task 1: Audit research command modes and classify behavioral instructions
-- [ ] Task 2: Design parent `research/SKILL.md` (orientation + family conventions)
-- [ ] Task 3: Convert research-setup (scaffolding mode — creates research directory structure)
+- [x] Task 1: Audit research command modes and classify behavioral instructions
+- [x] Task 2: Design parent `research/SKILL.md` (orientation + family conventions)
+- [x] Task 3: Convert research-setup (scaffolding mode — creates research directory structure)
 
 ### Research Child Skills
 - [ ] Task 4: Convert research-conduct (most complex: source evaluation + finding quality + requirement discovery)

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage2/status-and-next-steps.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage2/status-and-next-steps.md
@@ -1,17 +1,17 @@
 # Status & Next Steps — Stage 2: Researcher
 
-**Status:** 🔴 Not Started
+**Status:** 🟠 In Progress
 **Last Updated:** 2026-05-02
 
 ---
 
 ## 📊 Progress Summary
 
-**Overall:** 0/15 tasks complete
+**Overall:** 3/15 tasks complete
 
 | Group | Status | Progress | Notes |
 |-------|--------|----------|-------|
-| Research Family Foundation | 🔴 Not Started | 0/3 tasks | Audit + parent + setup |
+| Research Family Foundation | ✅ Complete | 3/3 tasks | Audit artifact, parent SKILL, research-setup |
 | Research Child Skills | 🔴 Not Started | 0/4 tasks | conduct + consolidate + add-topic decision + validation |
 | Standalone Skills (Spike + Reflect) | 🔴 Not Started | 0/4 tasks | Two standalone conversions |
 | Cutover and Quality Gate | 🔴 Not Started | 0/4 tasks | Install, regression test, final sweep |
@@ -20,9 +20,9 @@
 
 ## 🚀 Next Steps
 
-1. **Expand Group 1** — add detailed task specs for Research Family Foundation
-2. **Start Group 1** — audit research command, design parent, convert setup
-3. **Agent orchestration** — first live test of `.agents/group-cycle.agent.md`
+1. **Group 2** — research-conduct, research-consolidate, Task 6 add-topic placement, end-to-end validation
+2. **Group 3** — spike + reflect standalone skills
+3. **Group 4** — cutover, regression, rubric sweep, exit criteria
 
 ---
 
@@ -30,8 +30,7 @@
 
 - Stage 2 entry criteria met: Stage 1 complete, family pattern proven on explore
 - research-conduct is the go/no-go signal for this stage (most complex command in v1)
-- Conversion patterns established in Stage 1: five-property rubric, templates-as-assets, family structure, clean cutover
-- First stage to use the group-cycle agent for dispatch
+- Group 1 audit: `planning-stage2/artifacts/research-command-audit.md`
 
 ---
 

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage2/tasks/01-research-family-foundation.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage2/tasks/01-research-family-foundation.md
@@ -1,35 +1,40 @@
 # Research Family Foundation
 
-**Feature:** Agentic Workflow Modernization (Stage 2: Researcher)
-**Group:** Research Family Foundation
-**Status:** 🔴 Scaffolding (needs expansion)
+**Feature:** Agentic Workflow Modernization (Stage 2: Researcher)  
+**Group:** Research Family Foundation  
+**Status:** 🟠 In Progress — Task 1 complete  
 **Last Updated:** 2026-05-02
 
 ---
 
 ## 📝 Tasks
 
-- [ ] Task 1: Audit research command modes and classify behavioral instructions
-  - Read `.cursor/commands/research.md` (1,531 lines)
-  - Identify all modes: setup, conduct, consolidate, add-topic
-  - Classify each behavioral instruction using the precision tier framework (Topic 8 audit pattern from Stage 1)
-  - Map which instructions belong to which child skill
-  - Document the audit in chat (same pattern as Task 5 in Stage 1)
+- [x] Task 1: Audit research command modes and classify behavioral instructions
+  - **Purpose:** Produce a conversion map (modes → child skills) and a Topic 8–style tier inventory before authoring skills.
+  - **Steps:**
+    1. Read `.cursor/commands/research.md` and segment by mode (setup, add-topic, conduct, consolidate).
+    2. Map each mode to `research-setup`, `research-conduct`, or `research-consolidate`.
+    3. List behavioral or judgment-heavy instructions; assign Tier 1 / 2 / 3 and note rubric gaps for later groups.
+  - **Files:** `planning-stage2/artifacts/research-command-audit.md`
+  - **Acceptance:** Audit committed; includes mode→skill table and tier table(s); references Topic 8 / Stage 1 discuss audit pattern.
 
 - [ ] Task 2: Design parent `research/SKILL.md` (orientation + family conventions)
-  - Follow the explore family pattern established in Stage 1
-  - Parent provides: family overview, when to use each child, shared conventions
-  - Parent does NOT contain procedural steps — those live in children
-  - Reference: `.claude/skills/explore/SKILL.md` as the proven template
-  - Author in `templates/standard-project/.claude/skills/research/SKILL.md`
+  - **Purpose:** Give children a single place for path detection, topic naming, commit scope, and pipeline orientation (mirror `explore/SKILL.md`).
+  - **Steps:**
+    1. Read `templates/standard-project/.claude/skills/explore/SKILL.md` for tone and structure.
+    2. Author parent with `disable-model-invocation: true`, children table, conventions, when-NOT-to-use, related links.
+    3. Do **not** embed procedural setup/conduct/consolidate steps — those belong in children.
+  - **Files:** `templates/standard-project/.claude/skills/research/SKILL.md`
+  - **Acceptance:** Parent exists; references explore for exploration paths; documents v1 filename split (`research-*.md` vs `topic-N-*.md`); no procedural mode steps in body.
 
 - [ ] Task 3: Convert research-setup (scaffolding mode)
-  - Extract setup-mode instructions from research command audit (Task 1)
-  - research-setup creates the research directory structure, topic list, and initial scaffolding
-  - Include research-add-topic behavior here (pending Task 6 verification)
-  - Apply five-property rubric (FR-19)
-  - Populate gotchas section
-  - Author in `templates/standard-project/.claude/skills/research/research-setup/SKILL.md`
+  - **Purpose:** Capture initial setup + add-topic behavior in one child skill per group plan (add-topic final placement verified in Task 6).
+  - **Steps:**
+    1. Extract setup Steps 1–7 and Add Topic workflow from the command audit / source command.
+    2. Author child with `read ../SKILL.md` preamble; separate **Setup** and **Add topic** workflows.
+    3. Add **Behavioral Contract** and **Gotchas**; apply FR-19 — every behavioral line observable, bounded, outcome-framed, delta-only, failure-aware.
+  - **Files:** `templates/standard-project/.claude/skills/research/research-setup/SKILL.md`
+  - **Acceptance:** Skill is self-contained for scaffolding; explicitly forbids web research / conduct work; add-topic conflicts and exploration path gotchas documented.
 
 ---
 
@@ -43,9 +48,9 @@
 
 ## ✅ Completion Criteria
 
-- [ ] Research command audit complete with mode/instruction classification
+- [x] Research command audit complete with mode/instruction classification
 - [ ] Parent SKILL.md authored with family conventions
-- [ ] research-setup skill passes five-property rubric
+- [ ] research-setup skill passes five-property rubric (behavioral contract + gotchas)
 - [ ] Family directory structure in place: `research/SKILL.md`, `research/research-setup/SKILL.md`
 
 ---

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage2/tasks/01-research-family-foundation.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage2/tasks/01-research-family-foundation.md
@@ -2,7 +2,7 @@
 
 **Feature:** Agentic Workflow Modernization (Stage 2: Researcher)  
 **Group:** Research Family Foundation  
-**Status:** 🟠 In Progress — Tasks 1–2 complete  
+**Status:** ✅ Expanded — Group 1 execution complete  
 **Last Updated:** 2026-05-02
 
 ---
@@ -27,7 +27,7 @@
   - **Files:** `templates/standard-project/.claude/skills/research/SKILL.md`
   - **Acceptance:** Parent exists; references explore for exploration paths; documents v1 filename split (`research-*.md` vs `topic-N-*.md`); no procedural mode steps in body.
 
-- [ ] Task 3: Convert research-setup (scaffolding mode)
+- [x] Task 3: Convert research-setup (scaffolding mode)
   - **Purpose:** Capture initial setup + add-topic behavior in one child skill per group plan (add-topic final placement verified in Task 6).
   - **Steps:**
     1. Extract setup Steps 1–7 and Add Topic workflow from the command audit / source command.
@@ -50,8 +50,8 @@
 
 - [x] Research command audit complete with mode/instruction classification
 - [x] Parent SKILL.md authored with family conventions
-- [ ] research-setup skill passes five-property rubric (behavioral contract + gotchas)
-- [ ] Family directory structure in place: `research/SKILL.md`, `research/research-setup/SKILL.md`
+- [x] research-setup skill passes five-property rubric (behavioral contract + gotchas)
+- [x] Family directory structure in place: `research/SKILL.md`, `research/research-setup/SKILL.md`
 
 ---
 

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage2/tasks/01-research-family-foundation.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage2/tasks/01-research-family-foundation.md
@@ -2,7 +2,7 @@
 
 **Feature:** Agentic Workflow Modernization (Stage 2: Researcher)  
 **Group:** Research Family Foundation  
-**Status:** 🟠 In Progress — Task 1 complete  
+**Status:** 🟠 In Progress — Tasks 1–2 complete  
 **Last Updated:** 2026-05-02
 
 ---
@@ -18,7 +18,7 @@
   - **Files:** `planning-stage2/artifacts/research-command-audit.md`
   - **Acceptance:** Audit committed; includes mode→skill table and tier table(s); references Topic 8 / Stage 1 discuss audit pattern.
 
-- [ ] Task 2: Design parent `research/SKILL.md` (orientation + family conventions)
+- [x] Task 2: Design parent `research/SKILL.md` (orientation + family conventions)
   - **Purpose:** Give children a single place for path detection, topic naming, commit scope, and pipeline orientation (mirror `explore/SKILL.md`).
   - **Steps:**
     1. Read `templates/standard-project/.claude/skills/explore/SKILL.md` for tone and structure.
@@ -49,7 +49,7 @@
 ## ✅ Completion Criteria
 
 - [x] Research command audit complete with mode/instruction classification
-- [ ] Parent SKILL.md authored with family conventions
+- [x] Parent SKILL.md authored with family conventions
 - [ ] research-setup skill passes five-property rubric (behavioral contract + gotchas)
 - [ ] Family directory structure in place: `research/SKILL.md`, `research/research-setup/SKILL.md`
 

--- a/templates/standard-project/.claude/skills/research/SKILL.md
+++ b/templates/standard-project/.claude/skills/research/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: research
+description: >-
+  Research family parent. Provides orientation and shared conventions for
+  research-setup, research-conduct, and research-consolidate. Do NOT invoke
+  this skill directly — use a child skill listed below. Read this file when a
+  child instructs you to load family conventions.
+disable-model-invocation: true
+---
+
+# Research — Skill Family
+
+Structured research from exploration or reflection through requirements ready
+for decisions. This family replaces the multi-mode `/research` command:
+
+```
+research-setup → (human review) → research-conduct → (human review) → research-consolidate → /decision → /transition-plan
+         ↑
+    explore output & explore-amend (new topics in research-topics.md)
+```
+
+## Available Skills
+
+| Skill | When to use |
+|-------|-------------|
+| **research-setup** | Initial scaffolding from exploration, reflection, or direct topic; **or** scaffold a late topic (`--add-topic` equivalent) into existing research |
+| **research-conduct** | Fill research documents with findings, analysis, and requirements (web research, updates to summary and hub) |
+| **research-consolidate** | After all topics are complete — reconcile exploration, dedupe and clean `requirements.md`, human-approved edits, Draft → Final |
+
+**Conduct** and **consolidate** are separate skills so the largest behavioral
+contracts stay isolated and reviewable (same rationale as explore separating
+start vs amend).
+
+## Family Conventions
+
+Children that reference this parent (`read ../SKILL.md`) inherit these
+conventions. A child MAY operate without reading the parent — opt-in, not
+platform-enforced.
+
+### Path Detection
+
+Detect structure **once** per invocation and stay consistent.
+
+**Research directory (topic container):**
+
+| Structure | Research path |
+|-----------|---------------|
+| Dev-infra | `admin/services/[service]/features/[topic]/research/` |
+| Template project | `docs/maintainers/research/[topic]/` |
+| Project-wide (maintainers research root exists) | `docs/maintainers/research/[topic]/` |
+
+**Detection rule:** If `admin/services/` exists, use the dev-infra row (research
+lives under the feature directory for that topic). If `docs/maintainers/research/`
+exists and the dev-infra layout does not apply, use template / project-wide rows
+as in the source `/research` command.
+
+**Explorations (for `--from-explore`):** Use the **same exploration paths as the
+explore family** — read `../explore/SKILL.md` Path Detection. Research reads
+`research-topics.md` from the resolved exploration directory.
+
+### Topic Naming
+
+Sanitize research topic names to kebab-case: lowercase, hyphens for spaces, no
+special characters. Align with explore family topic naming.
+
+### Output Sizing (orientation)
+
+| Artifact | Role |
+|----------|------|
+| Research hub `README.md` | Index + status table |
+| Per-topic research docs | Question, methodology, findings, requirements discovered |
+| `research-summary.md` | Cross-topic rollup |
+| `requirements.md` | FR / NFR / constraints / assumptions |
+
+Exact line targets live in **research-setup** (scaffolding) and
+**research-conduct** (filled artifacts).
+
+### Commit Discipline
+
+Research artifacts are documentation. Use `docs(research):` commit scope unless
+the project’s AGENTS.md prescribes a different pattern for maintainer docs.
+
+### Filename Conventions (v1)
+
+Initial setup creates per-topic files named `research-[question-name].md` (slug
+from the question). **Add-topic** scaffolding creates `topic-N-[name].md` for
+topic number `N` from `research-topics.md`. Both patterns may coexist in one
+research directory until a future naming cleanup.
+
+## When NOT to Use Research
+
+| Situation | Use instead |
+|-----------|-------------|
+| Unstructured thinking before topics exist | **explore-start** or **explore-amend** |
+| Conversation without file changes | **discuss** |
+| Personal growth / retro | **reflect** |
+| Time-boxed risk validation | **spike** |
+| Executing an implementation plan | **task** workflow |
+
+## Related
+
+- **Upstream:** explore → `research-topics.md`
+- **Downstream:** `/decision --from-research`, `/transition-plan --from-adr`
+- **Lateral:** **explore** family for exploration paths and amend loop

--- a/templates/standard-project/.claude/skills/research/research-setup/SKILL.md
+++ b/templates/standard-project/.claude/skills/research/research-setup/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: research-setup
+description: >-
+  Scaffold research directory layout for a topic: hub, per-topic documents from
+  exploration/reflection/direct input, requirements skeleton, summary, and
+  parent research index updates. Use when the user wants /research setup,
+  /research --from-explore, /research --from-reflect, or to add a late topic
+  (/research --add-topic N). Do NOT use for conducting research (research-conduct)
+  or consolidating requirements (research-consolidate).
+disable-model-invocation: true
+---
+
+# Research Setup
+
+Before proceeding, read `../SKILL.md` for family conventions (path detection,
+topic naming, commit discipline, filename conventions).
+
+You create **structure only**: templates and links so humans can review before
+long-running **research-conduct** work. Do not perform web research in this
+skill.
+
+---
+
+## Modes
+
+| Mode | Trigger | Outcome |
+|------|---------|--------|
+| **Setup** | Single input source: `--from-explore`, `--from-reflect`, or direct `--topic` / inline topic | New `research/[topic]/` tree (or dev-infra feature `research/`) |
+| **Add topic** | Research tree exists + topic index `N` from `research-topics.md` | New `topic-N-[name].md` + hub/summary updates |
+
+Accept **one** setup source only (explore **or** reflect **or** direct). Error
+if mutually exclusive flags would collide (same rules as legacy command:
+`--add-topic` excludes initial `--from-explore`).
+
+---
+
+## Setup Mode Workflow
+
+### 1. Identify research source and topics
+
+1. **`--from-explore [explore-topic]`:** Resolve exploration directory per
+   `../../explore/SKILL.md` Path Detection. Read `research-topics.md`. Derive
+   research topic directory name from CLI `--topic` if present, else align with
+   the exploration topic naming convention.
+2. **`--from-reflect [path]`:** Read the reflection file. Extract sections
+   titled **Actionable Suggestions** or **Opportunities for Improvement** (or
+   closest equivalent headings). Each distinct suggestion becomes a research
+   topic with a clear question line.
+3. **Direct topic:** Use `[topic]` from invocation. If there are no discrete
+   questions yet, ask the user for a numbered list of research questions before
+   creating files.
+
+**Checklist:** Source chosen; topic list explicit; target paths detected per
+family conventions.
+
+### 2. Create research directory and hub
+
+Create `README.md` for the research topic with:
+
+- Purpose, status 🔴 Research, created/updated dates
+- Quick links to `research-summary.md`, `requirements.md`, and each per-topic file
+- **Research status** table: one row per topic with 🔴 Not Started
+- Short research overview and next steps pointing to conduct then consolidate
+
+### 3. Create per-topic research documents
+
+For **each** topic, add one markdown file:
+
+- **Initial setup:** `research-[question-slug].md` where slug is kebab-case from
+  the question title.
+- Fill the scaffold sections: Research Question, Research Goals (checkbox list),
+  Methodology (placeholder), Sources checklist (include a line that web search
+  is expected **in conduct**), empty Findings / Analysis / Recommendations /
+  Requirements Discovered / Next Steps.
+
+Use the project’s established section headings so **research-conduct** can
+fill them without reformatting.
+
+### 4. Create `research-summary.md`
+
+Skeleton with overview counts, empty “Key Findings”, Requirements Summary pointer
+to `requirements.md`, and next steps listing conduct before consolidate.
+
+### 5. Create `requirements.md`
+
+Skeleton: Overview, Functional / Non-functional / Constraints / Assumptions
+sections with **no** fabricated FR IDs — status **Draft**. Optional placeholder
+lines inviting extraction during conduct.
+
+### 6. Update parent research index (if present)
+
+If the repo uses a parent `docs/maintainers/research/README.md` (or equivalent
+per detected layout), add this topic to Active Research with 🔴 Research
+status.
+
+### 7. Commit
+
+Commit all new paths with:
+
+`docs(research): scaffold [topic] research ([N] topics)`
+
+**Stop** after presenting what was created and where conduct should begin. Do
+not run web search or mark topics complete.
+
+---
+
+## Add Topic Mode Workflow
+
+### Preconditions
+
+1. Research directory for `[topic]` already exists.
+2. Read **exploration** `research-topics.md` from the same exploration pairing
+   used when research was created (resolve path per explore conventions).
+3. Topic **`N`** exists in that file (`### Topic N:` or equivalent heading).
+4. Target filename `topic-N-[name].md` must not exist unless the user explicitly
+   requests `--force` / overwrite.
+
+### Steps
+
+1. Parse topic block: Question, Context, Priority, and any listed methodology
+   hints.
+2. Create `topic-N-[name].md` using the **same section scaffold** as Setup step 3.
+3. Update hub `README.md` status table + quick link for the new file.
+4. Append placeholder subsection to `research-summary.md`:
+
+   `### Topic N: [Name] (🔴 Not Started)` + one line that findings arrive after conduct.
+
+5. Commit: `docs(research): scaffold topic N ([slug]) for [topic]`
+
+---
+
+## Behavioral Contract
+
+**Scaffold only.** Do not execute **research-conduct** (no web search, no filled
+findings, no “complete” status on topics).
+
+**One setup source** for initial setup; do not merge exploration and reflection
+inputs in a single run unless the user explicitly provides a single merged list
+(in that case treat as direct topic with enumerated questions).
+
+**Preserve slugs** consistently with topic titles; do not rename an existing
+research directory in this skill (new topic directory creation is **setup** on
+a new `[topic]` name only).
+
+**Never silently overwrite** reviewed artifacts. If paths exist, stop and
+request `--force` / user confirmation.
+
+**Observable completion:** Every listed topic has a file; hub lists each file;
+`requirements.md` and `research-summary.md` exist; commit succeeded.
+
+---
+
+## Gotchas
+
+**Wrong exploration path.** Dev-infra explorations live under
+`admin/services/.../explorations/`, not a flat `admin/explorations/` root. If
+`research-topics.md` is not found, re-resolve using **explore** path rules before
+creating duplicate directories.
+
+**Mixing filename conventions.** Initial topics may be `research-*.md` while
+amended topics use `topic-N-*.md`. Updating the hub table is mandatory so both
+are linked.
+
+**Skipping the commit.** Scaffolding without a commit makes the handoff to
+conduct fragile; always commit after setup or add-topic.
+
+**Running conduct inside setup.** Web search and filled findings belong in
+**research-conduct**. Doing them here blurs review gates and duplicates the
+largest behavioral contract.
+
+**Add-topic without exploration sync.** Topic `N` must exist in the exploration’s
+`research-topics.md`. If the user amended exploration but did not sync the
+file, stop and ask them to fix exploration first.
+
+---
+
+**Skill boundaries:** Setup + add-topic only. **research-conduct** fills
+content; **research-consolidate** cleans requirements after all topics are
+complete.

--- a/templates/standard-project/.claude/skills/research/research-setup/SKILL.md
+++ b/templates/standard-project/.claude/skills/research/research-setup/SKILL.md
@@ -32,6 +32,17 @@ Accept **one** setup source only (explore **or** reflect **or** direct). Error
 if mutually exclusive flags would collide (same rules as legacy command:
 `--add-topic` excludes initial `--from-explore`).
 
+**Natural-language invocation:** Map user intent to the same modes without
+requiring CLI flags. Examples: “Scaffold research from exploration *auth*” →
+Setup with from-explore; “Add topic 4 to this research” → Add topic with *N=4*.
+Confirm `N` and whether to overwrite when a target file already exists (equivalent
+to `--force`).
+
+**Layout detection failure:** After checking `../SKILL.md` path rules, if the
+repo matches **none** of the known layouts, **stop** and report which predicates
+were evaluated (`admin/services/`, `docs/maintainers/research/`, etc.). Do not
+create a new research tree under an assumed or ad-hoc root.
+
 ---
 
 ## Setup Mode Workflow


### PR DESCRIPTION
## Summary

- Audit the legacy `research.md` command (1,531 lines) using the Topic 8 precision tier framework, mapping modes to child skills and classifying behavioral instructions
- Author parent `research/SKILL.md` mirroring the explore family pattern — pipeline diagram, available skills table, family conventions (path detection, naming, commit discipline)
- Author `research/research-setup/SKILL.md` (190 lines) covering setup + add-topic workflows with behavioral contract and gotchas (FR-19)
- Expand Stage 2 Group 1 task file with detailed specs (purpose, steps, files, acceptance per task)
- Update Stage 2 implementation plan and status documents to reflect Group 1 completion (3/15 tasks)
- Address Sourcery feedback: fail-closed on unknown layout, natural-language invocation mapping

## Why

Stage 2 of the agentic-workflow-modernization converts the Researcher role group to skills. Group 1 establishes the research family foundation — the parent skill and first child (setup) — so that Groups 2-3 can build on a proven structure. This follows the same pattern as Stage 1's explore family: parent first, then children.

First group cycle executed by the `.agents/group-cycle.agent.md` pipeline on composer-2-fast — live validation of the agent orchestration spike.

## After Merge

- `templates/standard-project/.claude/skills/research/` directory now exists with parent and one child — future Group 2 PRs add `research-conduct/` and `research-consolidate/` alongside
- `planning-stage2/` status shows 3/15 tasks complete; Group 2 (Research Child Skills) is next
- Research command audit artifact at `planning-stage2/artifacts/research-command-audit.md` is a reference for Groups 2-3 conversions
- Two filename conventions coexist (`research-[slug].md` vs `topic-N-[name].md`) — deferred to Task 6 naming decision

## Follow-ups

- Task 6 (Group 2): Decide whether research-add-topic stays in research-setup or warrants a separate skill — also resolves the filename convention split
- Path detection alignment: parent and setup use explore-style paths, but legacy command examples differ — full doc cleanup deferred to post-Stage-2
