### PR TITLE
feat(agentic-workflow-modernization): Standalone Skills — Spike & Reflect (Group 3)

### DIFF
--- a/admin/feedback/deferred-tasks.md
+++ b/admin/feedback/deferred-tasks.md
@@ -582,3 +582,13 @@ This document tracks all medium (🟡) and low (🟢) priority tasks identified 
 - **PR87-Overall-#1 (🟡 MEDIUM):** Document handling of partially scaffolded research dirs (missing `research-summary.md` or topic files): route to research-setup vs stop.
 - **PR87-Overall-#2 (🟡 MEDIUM):** Define acceptable `web_search` failure modes and whether retries are expected before documenting abort in conduct.
 - **PR87-Overall-#3 (🟡 MEDIUM):** In `research-consolidate`, specify behavior when no paired exploration exists (skip with note vs error).
+
+---
+
+## PR #88 Additions
+
+**Date:** 2026-05-02  
+**Status:** Sourcery overall comments triaged
+
+- ~~**PR88-Overall-#1 (🟡 MEDIUM, 🟢 LOW effort):** `--actionable-only` missing from reflect Options table~~ — ✅ Fixed inline
+- **PR88-Overall-#2 (🟡 MEDIUM):** Generalize reflect workflow “recent merged PRs” step: phrase as provider-agnostic list with `gh pr list` as example (portability).

--- a/admin/feedback/sourcery/pr88.md
+++ b/admin/feedback/sourcery/pr88.md
@@ -1,0 +1,44 @@
+# Sourcery Review Analysis
+**PR**: #88
+**Repository**: grimm00/dev-infra
+**Generated**: Sat May  2 18:53:29 CDT 2026
+
+---
+
+## Summary
+
+Total Individual Comments: 0 + Overall Comments
+
+## Individual Comments
+
+## Overall Comments
+
+- In the reflect SKILL, `--actionable-only` is described in the workflow but not listed in the Options table; consider either adding it to the options table or dropping the mention so the surface and behavior stay aligned.
+- The reflect workflow currently hardcodes `gh pr list` usage; if this skill is meant to be reusable across environments, consider phrasing this as a generic 'list recent merged PRs' step with `gh` as an example implementation to avoid coupling the behavior to a specific CLI.
+
+## Priority Matrix Assessment
+
+| Comment | Priority | Impact | Effort | Action |
+|---------|----------|--------|--------|--------|
+| Overall-1: `--actionable-only` not in Options table | 🟡 MEDIUM | 🟢 LOW (doc consistency) | 🟢 LOW | **Fixed inline** — added row in `reflect/SKILL.md` Options |
+| Overall-2: `gh pr list` hardcoded in reflect workflow | 🟡 MEDIUM | 🟡 MEDIUM (portability) | 🟡 MEDIUM | **Deferred** — `admin/feedback/deferred-tasks.md` PR #88 |
+
+### Priority Levels
+- 🔴 **CRITICAL**: Security, stability, or core functionality issues
+- 🟠 **HIGH**: Bug risks or significant maintainability issues
+- 🟡 **MEDIUM**: Code quality and maintainability improvements
+- 🟢 **LOW**: Nice-to-have improvements
+
+### Impact Levels
+- 🔴 **CRITICAL**: Affects core functionality
+- 🟠 **HIGH**: User-facing or significant changes
+- 🟡 **MEDIUM**: Developer experience improvements
+- 🟢 **LOW**: Minor improvements
+
+### Effort Levels
+- 🟢 **LOW**: Simple, quick changes
+- 🟡 **MEDIUM**: Moderate complexity
+- 🟠 **HIGH**: Complex refactoring
+- 🔴 **VERY_HIGH**: Major rewrites
+
+

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage2/artifacts/reflect-command-audit.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage2/artifacts/reflect-command-audit.md
@@ -1,0 +1,84 @@
+# Reflect Command Audit — Behavioral Instructions and Tier Classification
+
+**Task:** Stage 2, Group 3, Task 10  
+**Date:** 2026-05-02  
+**Source:** `.cursor/commands/reflect.md` (~824 lines)  
+**Reference:** Tier definitions in [research-command-audit.md](research-command-audit.md)
+
+---
+
+## Tier Definitions (summary)
+
+| Tier | Description | Rubric properties (typical) |
+|------|-------------|----------------------------|
+| **Tier 1** | Precise — outcome-based, testable | Observable, bounded, outcome-framed, delta-only, failure-aware |
+| **Tier 2** | Mixed — directional but incomplete stopping rules | 3–4 properties |
+| **Tier 3** | Vague — unbounded judgment or persona | 0–2 properties |
+
+---
+
+## Core pattern: hybrid skill (procedural + personal-growth synthesis)
+
+`/reflect` is **hybrid** like `/narrative`:
+
+- **Procedural (Tier 1 heavy):** Fixed gather steps (commits, PRs, status docs), suggestion **shape** (priority, category, effort), reflection **file location** rules, commit/branch naming for docs-only workflow.
+- **Behavioral / synthesis (Tier 2):** “Thoughtful analysis,” identifying patterns, prioritizing suggestions, calibrating what counts as evidence — must be tightened in SKILL **Behavioral Contract** to Tier-1-style outcomes (evidence cited, no fabricated metrics, honest uncertainty).
+
+---
+
+## Path and structure (must not be lost)
+
+| Surface | Reflection output path | Notes |
+|---------|------------------------|-------|
+| **dev-infra** | `admin/planning/notes/reflections/reflection-[topic]-[date].md` | Command explicitly centralizes dev-infra reflections |
+| **Template — feature** | `docs/maintainers/planning/features/[feature]/reflections/...` | Hub README update when exists |
+| **Template — project-wide** | `docs/maintainers/planning/notes/reflections/...` or alternate `docs/maintainers/planning/reflections/...` | Detect from status doc layout |
+
+Learnings inputs: `--include-learnings` vs `all`; cross-phase pattern grouping — **Tier 2** synthesis unless bounded by “list recurring strings / counts from files.”
+
+---
+
+## Behavioral / judgment-rich instructions (by area)
+
+### Steps 1–4 — Gather and classify
+
+| ID | Instruction (paraphrase) | Tier | Notes |
+|----|--------------------------|------|-------|
+| G1 | Analyze recent commits, PRs, status, optional learnings | **T1** | Tool-assisted; outputs listed |
+| G2 | Identify dev vs workflow vs doc patterns | **T2** | Pattern quality depends on interpretation |
+| G3 | `--include-learnings all`: cluster recurring successes/issues | **T2** | Needs explicit “cite phase/file for each cluster” in skill |
+
+### Step 5 — Suggestions
+
+| ID | Instruction (paraphrase) | Tier | Notes |
+|----|--------------------------|------|-------|
+| S1 | Priority 🔴🟡🟢 + category + effort Quick/Moderate/Significant | **T1** | Format is structured |
+| S2 | Each suggestion: context, suggestion, benefits, next steps | **T1** | Template in command |
+| S3 | “Thoughtful,” “strategic” framing in overview | **T3** in prose | Replace with outcome rules in SKILL |
+
+### Step 6 — Reflection report
+
+| ID | Instruction (paraphrase) | Tier | Notes |
+|----|--------------------------|------|-------|
+| R1 | Large report scaffold: Current State, Working Well, Opportunities, Issues, Suggestions, Next Steps, Trends | **T1** | File structure observable |
+| R2 | Optional cross-phase section when `--include-learnings all` | **T1** | Conditional block |
+| R3 | Update reflections README when exists | **T1** | Checklist |
+
+### Step 8 — Commit workflow
+
+| ID | Instruction (paraphrase) | Tier | Notes |
+|----|--------------------------|------|-------|
+| P1 | Docs-only branch, merge to develop, delete branch | **T1** | Procedural; platform may vary — skill should describe intended git sequence without assuming GitHub |
+
+---
+
+## Conversion notes (Task 11)
+
+- Mirror **narrative** hybrid: procedural workflow + **Behavioral Contract** for tone/evidence (ground claims, omit empty sections, no invented metrics).
+- Preserve **dev-infra centralized path** as first-class detection branch.
+- Collapse 800+ lines into skill-sized workflow; link **templates/reflection-report.md** for long scaffold.
+- **Gotchas:** vague suggestions, wrong output path for dev-infra, skipping README hub update, treating reflect as int-opp (different artifact purpose).
+
+---
+
+**Last Updated:** 2026-05-02

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage2/artifacts/spike-command-audit.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage2/artifacts/spike-command-audit.md
@@ -1,0 +1,91 @@
+# Spike Command Audit — Behavioral Instructions and Tier Classification
+
+**Task:** Stage 2, Group 3, Task 8  
+**Date:** 2026-05-02  
+**Source:** `.cursor/commands/spike.md` (~481 lines)  
+**Reference:** Tier definitions in [research-command-audit.md](research-command-audit.md) (same five-property rubric as Stage 1 Topic 8)
+
+---
+
+## Tier Definitions (summary)
+
+| Tier | Description | Rubric properties (typical) |
+|------|-------------|----------------------------|
+| **Tier 1** | Precise — outcome-based, testable | Observable, bounded, outcome-framed, delta-only, failure-aware |
+| **Tier 2** | Mixed — directional but incomplete stopping rules | 3–4 properties |
+| **Tier 3** | Vague — unbounded judgment or persona | 0–2 properties |
+
+---
+
+## Core pattern: time-boxed behavioral contract
+
+The command’s durable “contract” (what a skill must preserve) is **not** the directory layout alone; it is the coupling of:
+
+1. **Criteria before build** — Success criteria stated and shown to the user *before* substantive spike work (Step 2; checklist).
+2. **Bounded duration** — Explicit timer / `--time-box`; **stop when time expires** and still document (Step 3, Scenario 4, Tips).
+3. **Throwaway scope** — Minimal prototype, no polish; spike code may be discarded (Step 3 “Key principles”).
+4. **Evidence-backed learnings** — `spike-learnings.md` ties answers to observations (errors, behavior, edge-case table); **Go / No-Go** is explicit (Step 4 template).
+5. **Commit the artifact** — Learnings file committed; spike subdirectory often not tracked (Step 5).
+
+These items map cleanly to **Tier 1** when expressed as outcomes (what files show, when to stop, what must appear in learnings).
+
+---
+
+## Behavioral / judgment-rich instructions (by area)
+
+### Workflow overview & when to use
+
+| ID | Instruction (paraphrase) | Tier | Notes |
+|----|--------------------------|------|-------|
+| W1 | Use spike when uncertainty is “can it work?”; use research for “what’s best?” | **T1–T2** | Binary routing is clear; edge cases between “compare options” vs “prove viability” need user judgment |
+| W2 | Risk framework: HIGH risk + “will this work?” → spike | **T2** | “HIGH risk” label comes from exploration, not always explicit in repo |
+| W3 | Hands-on validation vs desk research | **T1** | Observable choice of activity type |
+
+### Step 1 — Questions to validate
+
+| ID | Instruction (paraphrase) | Tier | Notes |
+|----|--------------------------|------|-------|
+| Q1 | Extract technical questions, edge cases, success criteria from exploration | **T2** | Quality of “what to validate” depends on reading exploration docs |
+| Q2 | Prefer “can it work?” over “what’s best?” | **T1** | Decision rule is phrased as observable question form |
+
+### Step 2 — Success criteria
+
+| ID | Instruction (paraphrase) | Tier | Notes |
+|----|--------------------------|------|-------|
+| C1 | Criteria before building; specific and testable | **T1** | Checklist + template enforce ordering |
+| C2 | Agree time-box duration (default 2–4h) | **T1** | User-visible; `--time-box` bounds |
+
+### Step 3 — Build minimal prototype
+
+| ID | Instruction (paraphrase) | Tier | Notes |
+|----|--------------------------|------|-------|
+| B1 | Throwaway mindset; minimal scope; real environment | **T2** | “Minimal” and “real” need calibration; **failure mode:** over-building |
+| B2 | Stop when timer ends; document regardless | **T1** | Clear stop rule |
+| B3 | AI “assists” — human-driven step | **T2** | Division of labor not enforceable in prose alone |
+
+### Step 4 — Document learnings
+
+| ID | Instruction (paraphrase) | Tier | Notes |
+|----|--------------------------|------|-------|
+| D1 | Template sections: Questions Answered, Findings, Edge Cases, Go/No-Go, Refined Questions | **T1** | Observable structure |
+| D2 | Findings include specific evidence | **T1** | Matches rubric “observable” |
+| D3 | `--document-learnings` skips to documentation | **T1** | Mode flag |
+
+### Tips & scenarios
+
+| ID | Instruction (paraphrase) | Tier | Notes |
+|----|--------------------------|------|-------|
+| T1 | Don’t polish; document as you go | **T1** | Behavioral lines convertible to skill gotchas + contract |
+
+---
+
+## Conversion notes (Task 9)
+
+- **Standalone skill:** Flat `spike/` directory (ADR-002); no parent SKILL — unlike research children.
+- **Preserve:** Path detection matrix (dev-infra / template / lightweight); integration bullets pointing to explore/research/decision can become a short **Related** section.
+- **Lift to Behavioral Contract:** criteria-first, timer stop, throwaway scope, evidence in learnings, commit learnings (not necessarily throwaway code).
+- **Gotchas:** scope creep, skipping success criteria, polishing spike code, confusing spike vs research/POC, forgetting commit — all grounded in command Tips/Scenarios.
+
+---
+
+**Last Updated:** 2026-05-02

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage2/implementation-plan.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage2/implementation-plan.md
@@ -67,10 +67,10 @@ Convert the **Researcher** role group of dev-infra commands to skills. This stag
 - [x] Task 7: Validate research family pattern works end-to-end (parent → setup → conduct → consolidate)
 
 ### Standalone Skills (Spike + Reflect)
-- [ ] Task 8: Audit spike command for behavioral instructions
-- [ ] Task 9: Convert spike to SKILL.md (time-boxed behavioral contract)
-- [ ] Task 10: Audit reflect command for behavioral instructions
-- [ ] Task 11: Convert reflect to SKILL.md (personal growth behavioral contract)
+- [x] Task 8: Audit spike command for behavioral instructions
+- [x] Task 9: Convert spike to SKILL.md (time-boxed behavioral contract)
+- [x] Task 10: Audit reflect command for behavioral instructions
+- [x] Task 11: Convert reflect to SKILL.md (personal growth behavioral contract)
 
 ### Cutover and Quality Gate
 - [ ] Task 12: Install skills + archive commands (research, spike, reflect)

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage2/status-and-next-steps.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage2/status-and-next-steps.md
@@ -7,21 +7,20 @@
 
 ## 📊 Progress Summary
 
-**Overall:** 7/15 tasks complete
+**Overall:** 11/15 tasks complete
 
 | Group | Status | Progress | Notes |
 |-------|--------|----------|-------|
 | Research Family Foundation | ✅ Complete | 3/3 tasks | Audit artifact, parent SKILL, research-setup |
 | Research Child Skills | ✅ Complete | 4/4 tasks | research-conduct, research-consolidate, add-topic decision, validation |
-| Standalone Skills (Spike + Reflect) | 🔴 Not Started | 0/4 tasks | Two standalone conversions |
+| Standalone Skills (Spike + Reflect) | ✅ Complete | 4/4 tasks | spike + reflect skills + audits |
 | Cutover and Quality Gate | 🔴 Not Started | 0/4 tasks | Install, regression test, final sweep |
 
 ---
 
 ## 🚀 Next Steps
 
-1. **Group 3** — spike + reflect standalone skills
-2. **Group 4** — cutover, regression, rubric sweep, exit criteria
+1. **Group 4** — cutover, regression, rubric sweep, exit criteria
 
 ---
 
@@ -30,6 +29,7 @@
 - Stage 2 entry criteria met: Stage 1 complete, family pattern proven on explore
 - research-conduct is the go/no-go signal for this stage (most complex command in v1)
 - Group 1 audit: `planning-stage2/artifacts/research-command-audit.md`
+- Group 3 audits: `planning-stage2/artifacts/spike-command-audit.md`, `planning-stage2/artifacts/reflect-command-audit.md`
 
 ---
 

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage2/tasks/03-standalone-skills.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage2/tasks/03-standalone-skills.md
@@ -28,7 +28,7 @@
   - **Files:** `templates/standard-project/.claude/skills/spike/SKILL.md`, `templates/standard-project/.claude/skills/spike/templates/spike-learnings.md`
   - **Acceptance:** Skill is self-contained (no parent read); dry-run/document-learnings/time-box/force behaviors preserved; rubric passes; gotchas populated from audit + command tips.
 
-- [ ] Task 10: Audit reflect command for behavioral instructions
+- [x] Task 10: Audit reflect command for behavioral instructions
   - **Purpose:** Classify reflect’s hybrid surface (long procedural report + synthesis judgment); isolate **personal-growth / suggestion-quality contract** for Task 11.
   - **Steps:**
     1. Read `.cursor/commands/reflect.md`; separate path/config, procedural steps (Steps 1–6, 8), vs tone/synthesis guidance (Tips, suggestion quality).

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage2/tasks/03-standalone-skills.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage2/tasks/03-standalone-skills.md
@@ -18,7 +18,7 @@
   - **Files:** `planning-stage2/artifacts/spike-command-audit.md`
   - **Acceptance:** Audit cites command sections; time-box contract called out; tiers documented; file linkable from this group file.
 
-- [ ] Task 9: Convert spike to SKILL.md
+- [x] Task 9: Convert spike to SKILL.md
   - **Purpose:** Replace `/spike` with a standalone skill: procedural flow (questions → success criteria → minimal build → `spike-learnings.md` → commit) plus **time-boxed behavioral contract** and **gotchas**, mirroring int-opp/narrative one-shot skills (flat directory, templates co-located).
   - **Steps:**
     1. Read Task 8 audit and Stage 1 patterns in `int-opp/SKILL.md` / `narrative/SKILL.md`.

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage2/tasks/03-standalone-skills.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage2/tasks/03-standalone-skills.md
@@ -2,7 +2,7 @@
 
 **Feature:** Agentic Workflow Modernization (Stage 2: Researcher)
 **Group:** Standalone Skills (Spike + Reflect)
-**Status:** 🔴 Scaffolding (needs expansion)
+**Status:** ✅ Expanded
 **Last Updated:** 2026-05-02
 
 ---
@@ -10,30 +10,42 @@
 ## 📝 Tasks
 
 - [ ] Task 8: Audit spike command for behavioral instructions
-  - Read `.cursor/commands/spike.md` (481 lines)
-  - Classify behavioral instructions using precision tier framework
-  - Identify the time-boxed behavioral contract as the core pattern
-  - Document audit in chat
+  - **Purpose:** Classify spike’s judgment-heavy guidance with the same Tier 1–3 frame as Stage 2 research audit; isolate the **time-boxed behavioral contract** (criteria-before-build, throwaway scope, stop-at-timer, evidence-backed learnings) for Task 9.
+  - **Steps:**
+    1. Read `.cursor/commands/spike.md` end-to-end; note procedural steps vs tone/judgment sections (Key principles, Guidance for the spike, Tips).
+    2. For each behavioral cluster, assign Tier 1–3 using [Topic 8 rubric](../artifacts/research-command-audit.md) (observable, bounded, outcome-framed, delta-only, failure-aware).
+    3. Write `planning-stage2/artifacts/spike-command-audit.md` (tier table + core contract summary + conversion notes for SKILL.md).
+  - **Files:** `planning-stage2/artifacts/spike-command-audit.md`
+  - **Acceptance:** Audit cites command sections; time-box contract called out; tiers documented; file linkable from this group file.
 
 - [ ] Task 9: Convert spike to SKILL.md
-  - Spike is a single-mode skill with a time-boxed behavioral contract
-  - Same pattern as int-opp/narrative from Stage 1 (standalone, not a family)
-  - Apply five-property rubric
-  - Populate gotchas section
-  - Author in `templates/standard-project/.claude/skills/spike/SKILL.md`
+  - **Purpose:** Replace `/spike` with a standalone skill: procedural flow (questions → success criteria → minimal build → `spike-learnings.md` → commit) plus **time-boxed behavioral contract** and **gotchas**, mirroring int-opp/narrative one-shot skills (flat directory, templates co-located).
+  - **Steps:**
+    1. Read Task 8 audit and Stage 1 patterns in `int-opp/SKILL.md` / `narrative/SKILL.md`.
+    2. Author `templates/standard-project/.claude/skills/spike/SKILL.md` with YAML frontmatter, path detection, options table, workflow, **Behavioral Contract**, **Gotchas**.
+    3. Add co-located template `templates/spike-learnings.md`; SKILL instructs copy-then-fill like narrative.
+    4. Map every **Behavioral Contract** bullet to the five-property rubric (same wording convention as research children).
+  - **Files:** `templates/standard-project/.claude/skills/spike/SKILL.md`, `templates/standard-project/.claude/skills/spike/templates/spike-learnings.md`
+  - **Acceptance:** Skill is self-contained (no parent read); dry-run/document-learnings/time-box/force behaviors preserved; rubric passes; gotchas populated from audit + command tips.
 
 - [ ] Task 10: Audit reflect command for behavioral instructions
-  - Read `.cursor/commands/reflect.md` (824 lines)
-  - Classify behavioral instructions using precision tier framework
-  - Identify the personal growth behavioral contract as the core pattern
-  - Document audit in chat
+  - **Purpose:** Classify reflect’s hybrid surface (long procedural report + synthesis judgment); isolate **personal-growth / suggestion-quality contract** for Task 11.
+  - **Steps:**
+    1. Read `.cursor/commands/reflect.md`; separate path/config, procedural steps (Steps 1–6, 8), vs tone/synthesis guidance (Tips, suggestion quality).
+    2. Tier behavioral lines per research audit frame; flag dev-infra-specific reflection path rules vs template paths.
+    3. Write `planning-stage2/artifacts/reflect-command-audit.md`.
+  - **Files:** `planning-stage2/artifacts/reflect-command-audit.md`
+  - **Acceptance:** Audit covers scopes/flags; hybrid pattern explicit; template vs dev-infra paths documented.
 
 - [ ] Task 11: Convert reflect to SKILL.md
-  - Reflect is a single-mode hybrid skill (procedural steps + behavioral contract for personal growth reflection)
-  - Same pattern as narrative from Stage 1
-  - Apply five-property rubric
-  - Populate gotchas section
-  - Author in `templates/standard-project/.claude/skills/reflect/SKILL.md`
+  - **Purpose:** Standalone hybrid skill: procedural flow (gather → patterns → opportunities/issues → structured suggestions → reflection file → hub optional → docs-branch commit) plus **behavioral contract** for honest, evidence-backed reflection; mirror narrative hybrid section.
+  - **Steps:**
+    1. Read Task 10 audit and `narrative/SKILL.md` hybrid + template pattern.
+    2. Author `templates/standard-project/.claude/skills/reflect/SKILL.md` with path detection (feature, project-wide, dev-infra centralized), flags table, workflow, reflection filename conventions, **Behavioral Contract**, **Gotchas**.
+    3. Add `templates/reflection-report.md` as scaffold; SKILL references it for Step 6 output.
+    4. Behavioral bullets satisfy five-property rubric; gotchas from audit + command failure modes.
+  - **Files:** `templates/standard-project/.claude/skills/reflect/SKILL.md`, `templates/standard-project/.claude/skills/reflect/templates/reflection-report.md`
+  - **Acceptance:** dev-infra `admin/planning/notes/reflections/` rule preserved; `--include-learnings all` behavior summarized; rubric + gotchas complete.
 
 ---
 
@@ -57,6 +69,13 @@
 
 - No dependency on Groups 1-2 (spike and reflect are independent of research family)
 - Could theoretically run in parallel with Group 2, but sequential is fine
+
+---
+
+## 🔗 Artifacts
+
+- Task 8: [spike-command-audit.md](../artifacts/spike-command-audit.md)
+- Task 10: [reflect-command-audit.md](../artifacts/reflect-command-audit.md)
 
 ---
 

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage2/tasks/03-standalone-skills.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage2/tasks/03-standalone-skills.md
@@ -9,7 +9,7 @@
 
 ## 📝 Tasks
 
-- [ ] Task 8: Audit spike command for behavioral instructions
+- [x] Task 8: Audit spike command for behavioral instructions
   - **Purpose:** Classify spike’s judgment-heavy guidance with the same Tier 1–3 frame as Stage 2 research audit; isolate the **time-boxed behavioral contract** (criteria-before-build, throwaway scope, stop-at-timer, evidence-backed learnings) for Task 9.
   - **Steps:**
     1. Read `.cursor/commands/spike.md` end-to-end; note procedural steps vs tone/judgment sections (Key principles, Guidance for the spike, Tips).

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage2/tasks/03-standalone-skills.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage2/tasks/03-standalone-skills.md
@@ -2,7 +2,7 @@
 
 **Feature:** Agentic Workflow Modernization (Stage 2: Researcher)
 **Group:** Standalone Skills (Spike + Reflect)
-**Status:** ✅ Expanded
+**Status:** ✅ Complete
 **Last Updated:** 2026-05-02
 
 ---
@@ -37,7 +37,7 @@
   - **Files:** `planning-stage2/artifacts/reflect-command-audit.md`
   - **Acceptance:** Audit covers scopes/flags; hybrid pattern explicit; template vs dev-infra paths documented.
 
-- [ ] Task 11: Convert reflect to SKILL.md
+- [x] Task 11: Convert reflect to SKILL.md
   - **Purpose:** Standalone hybrid skill: procedural flow (gather → patterns → opportunities/issues → structured suggestions → reflection file → hub optional → docs-branch commit) plus **behavioral contract** for honest, evidence-backed reflection; mirror narrative hybrid section.
   - **Steps:**
     1. Read Task 10 audit and `narrative/SKILL.md` hybrid + template pattern.
@@ -58,10 +58,10 @@
 
 ## ✅ Completion Criteria
 
-- [ ] spike skill passes five-property rubric
-- [ ] reflect skill passes five-property rubric
-- [ ] Both include populated gotchas sections
-- [ ] Both authored in `templates/standard-project/.claude/skills/`
+- [x] spike skill passes five-property rubric
+- [x] reflect skill passes five-property rubric
+- [x] Both include populated gotchas sections
+- [x] Both authored in `templates/standard-project/.claude/skills/`
 
 ---
 

--- a/templates/standard-project/.claude/skills/reflect/SKILL.md
+++ b/templates/standard-project/.claude/skills/reflect/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: reflect
+description: >-
+  Analyze project state after substantial work: synthesize recent commits, PRs,
+  status, and optional phase learnings into a structured reflection with
+  actionable suggestions. Use when the user invokes /reflect or wants a calm
+  review of patterns and next steps. Do NOT replace /int-opp — reflect produces
+  a reflection artifact; int-opp captures template-facing opportunities.
+disable-model-invocation: true
+---
+
+# Reflect
+
+Produce a **structured reflection** on project state: what is working, what
+could improve, and **evidence-backed** suggestions. This is a **hybrid skill** —
+deterministic gather/write steps plus judgment about emphasis — bounded by the
+behavioral contract.
+
+```
+detect paths → gather → patterns → opportunities & risks → suggestions → write report → hub link → commit
+```
+
+## Templates
+
+| Template | When to use |
+|----------|-------------|
+| `templates/reflection-report.md` | Always — copy to target path, then fill |
+
+## Path detection
+
+| Context | Status doc | Reflection output directory | Filename pattern |
+|---------|------------|----------------------------|------------------|
+| **Dev-infra** | Feature planning under `admin/services/.../features/[feature]/` **or** service meta; also read root `AGENTS.md` context | **`admin/planning/notes/reflections/`** (centralized) | `reflection-[topic]-YYYY-MM-DD.md` |
+| **Template — feature** | `docs/maintainers/planning/features/[feature]/status-and-next-steps.md` | `docs/maintainers/planning/features/[feature]/reflections/` | `reflection-[scope]-YYYY-MM-DD.md` |
+| **Template — project-wide** | `docs/maintainers/planning/status-and-next-steps.md` (if present) | `docs/maintainers/planning/notes/reflections/` or `docs/maintainers/planning/reflections/` | `reflection-[scope]-YYYY-MM-DD.md` |
+
+**Feature name:** `--feature` if provided; else inferred from single feature folder or status doc path.
+
+**Learnings inputs (optional):**
+
+- `--include-learnings` — latest phase learnings for the detected feature (search `docs/.../learnings/`, `admin/planning/opportunities/internal/.../learnings/` per command conventions).
+- `--include-learnings all` — read **all** phase learnings available for the feature; build **Cross-Phase** section only with citations per cluster.
+
+## When to use
+
+- After a major phase or release cadence
+- Before a big decision or replan
+- When the team wants a single readable snapshot (not a backlog dump)
+
+## Options (surface)
+
+| Flag / scope | Behavior |
+|--------------|----------|
+| `/reflect` | Full pass on detected default scope |
+| `/reflect --recent [days]` | Weight commits/PRs in last *days* (default 7) |
+| `/reflect --phase` | Anchor “Current State” on phase fields in status doc |
+| `/reflect --workflow` | Emphasize process friction over code observations |
+| `/reflect --code-quality` | Emphasize implementation patterns |
+| `/reflect --documentation` | Emphasize docs/hubs |
+| `/reflect --technical-debt` | Emphasize risk/defect themes |
+| `/reflect --include-fixes` | Pull deferred fix hubs into “Potential Issues” |
+| `--include-learnings` / `--include-learnings all` | As in Path detection |
+
+If flags conflict, prefer explicit `--feature` and the narrowest scope flag the user repeated last.
+
+## Workflow
+
+### 1. Gather context
+
+1. **Git:** Summarize `git log` for the period (`--recent` window or sensible default).
+2. **PRs:** `gh pr list --state merged --limit 10` when available; if unavailable, note **failure** in the report once.
+3. **Status:** Read the detected `status-and-next-steps.md`; capture current group/phase line verbatim where useful.
+4. **Learnings:** If requested, read learnings files completely before synthesis — do not invent summaries without file quotes or paraphrases tied to paths.
+
+**Checklist:** Period stated; status doc path cited; learnings paths listed when used.
+
+### 2. Pattern scan (bounded)
+
+From gather results only:
+
+- **Development:** testing hooks, review cadence, commit shape (observable).
+- **Workflow:** PR batching, docs updates, automation commands referenced in commits.
+- **Documentation:** hub/README drift *only if* filenames or missing links are observable.
+
+Avoid personality judgments; translate to **patterns** with **evidence** (commit subject, file path, metric).
+
+### 3. Opportunities and risks
+
+For each item:
+
+- **Opportunity:** named gap + **effort** guess (Quick / Moderate / Significant) + **first step**.
+- **Risk:** what could go wrong + **mitigation** + priority emoji.
+
+If evidence is weak, move item to **Open uncertainties** appendix instead of main lists.
+
+### 4. Build suggestions
+
+Each suggestion **must** follow the block format in `templates/reflection-report.md`:
+
+- Priority, effort, impact
+- Context with **citation** (path, PR #, or date range)
+- Numbered next steps
+
+**`--actionable-only`:** omit purely descriptive sections except **Current State**; keep only suggestion-shaped blocks.
+
+### 5. Write reflection file
+
+1. Copy `templates/reflection-report.md` to the resolved output path.
+2. Replace placeholders; **omit** sections that add no value (do not pad with N/A).
+3. For dev-infra, **always** use `admin/planning/notes/reflections/` even when reflecting a service feature — this matches the command’s centralization rule.
+
+### 6. Hub link
+
+If `reflections/README.md` exists beside the output, add this file to its index with one-line summary + date.
+
+### 7. Commit (docs-style)
+
+Reflections are documentation:
+
+1. Prefer branch `docs/reflect-[feature-or-scope]-YYYY-MM-DD` when not already on a docs branch (follow project Git Flow for docs merges).
+2. Commit message example:
+
+```text
+docs(reflection): create [scope] reflection
+
+- Analyzed [period]
+- Captured opportunities and risks with evidence
+```
+
+Push/merge per repo policy (`COMMIT-WORKFLOW.md` / maintainer guide). If tooling unavailable, stop after writing files and tell the user what is uncommitted.
+
+## Behavioral Contract
+
+**Evidence over vibe.** Claims tie to artifacts (paths, PR numbers, commit ranges). If data is missing, state the gap — **observable**, **failure-aware**.
+
+**Actionable, not lyrical.** Suggestions include a **next step** a reader could schedule — **outcome-framed**, **bounded** by the template sections.
+
+**Calibrated uncertainty.** Conflicting signals or thin data → short “Open uncertainties” instead of false precision — **failure-aware**, **delta-only** (only new synthesis beyond raw logs).
+
+**Scope discipline.** Reflect is not `/int-opp`: opportunity backlog for templates belongs in int-opp; reflect may **link** to existing opportunity docs rather than duplicating them — **delta-only**.
+
+**No fabricated metrics.** Percentages, coverage numbers, or phase counts must come from files or tools; otherwise omit — **observable**.
+
+## Gotchas
+
+**Wrong output path on dev-infra.** Feature planning still writes reflections under `admin/planning/notes/reflections/` — do not mirror template `docs/.../features/.../reflections/` on this repo layout.
+
+**Suggestion dumps.** Long unstructured bullet lists belong in drafts; ship the template sections or trim.
+
+**Skipping learnings files.** `--include-learnings all` requires actually reading each file — surface counts without filenames is insufficient.
+
+**Over-asserting from quiet repos.** Few commits in window → say so; do not dramatize.
+
+**Mixing personal critique with facts.** Keep “Potential Issues” tied to observable drift or explicit user-provided concerns.
+
+**Forgetting README hub updates.** If a reflections hub exists and you skip it, the artifact is harder to discover.
+
+## Related
+
+- `/int-opp` — capture template opportunities after phase work
+- `/research`, `/decision`, `/transition-plan` — downstream of reflection insights when strategic

--- a/templates/standard-project/.claude/skills/reflect/SKILL.md
+++ b/templates/standard-project/.claude/skills/reflect/SKILL.md
@@ -60,6 +60,7 @@ detect paths → gather → patterns → opportunities & risks → suggestions �
 | `/reflect --technical-debt` | Emphasize risk/defect themes |
 | `/reflect --include-fixes` | Pull deferred fix hubs into “Potential Issues” |
 | `--include-learnings` / `--include-learnings all` | As in Path detection |
+| `/reflect --actionable-only` | Emit Current State plus suggestion-shaped sections only |
 
 If flags conflict, prefer explicit `--feature` and the narrowest scope flag the user repeated last.
 

--- a/templates/standard-project/.claude/skills/reflect/templates/reflection-report.md
+++ b/templates/standard-project/.claude/skills/reflect/templates/reflection-report.md
@@ -1,0 +1,109 @@
+# Project Reflection — [Date or scope]
+
+**Scope:** [Full Project | Recent Work | Phase | Feature | …]  
+**Period:** [Time window analyzed]  
+**Generated:** YYYY-MM-DD
+
+---
+
+## Current State
+
+### Recent Activity
+
+- **Commits:** [N] in period (cite `git log` range)
+- **PRs merged:** [N] (cite `gh pr list` or note if unavailable)
+- **Current phase/feature:** [Name] ([status from status-and-next-steps.md])
+- **Documentation:** [e.g., hubs current / gaps named]
+
+### Key Metrics
+
+Only include metrics **grounded in repo artifacts**. If unknown, write “Not measured — [why]”.
+
+---
+
+## What's Working Well
+
+### [Category]
+
+**Pattern:** [What is working]  
+**Evidence:** [Commit, doc path, or observable behavior]  
+**Recommendation:** [Keep doing X]
+
+---
+
+## Opportunities for Improvement
+
+### [Category]
+
+**Issue:** [What could improve]  
+**Impact:** [Why it matters]  
+**Suggestion:** [Concrete next step]  
+**Effort:** [Quick | Moderate | Significant]
+
+---
+
+## Potential Issues
+
+### [Issue title]
+
+**Risk:** [Observable or documented risk]  
+**Impact:** [Who/what is affected]  
+**Mitigation:** [Specific action]  
+**Priority:** 🔴 / 🟡 / 🟢
+
+---
+
+## Actionable Suggestions
+
+Use the structured block per suggestion:
+
+### [Category]: [Title]
+
+**Priority:** 🔴 High | 🟡 Medium | 🟢 Low  
+**Effort:** Quick | Moderate | Significant  
+**Impact:** [One sentence]
+
+**Context:** [Evidence-backed reason this surfaced]
+
+**Suggestion:** [Specific change]
+
+**Next Steps:**
+1. [Step]
+
+**Related:** [Paths, PRs, docs]
+
+---
+
+## Recommended Next Steps
+
+1. **Immediate:** [items]
+2. **Short-term:** [items]
+3. **Long-term:** [items]
+
+---
+
+## Trends & Patterns
+
+### Positive trends
+
+- [Trend + evidence]
+
+### Areas of concern
+
+- [Concern + evidence]
+
+---
+
+## Cross-Phase Learnings (only if `--include-learnings all`)
+
+### Recurring successes
+
+- [Pattern — cite which learnings files]
+
+### Persistent issues
+
+- [Issue — cite frequency from files]
+
+---
+
+**Next reflection:** [suggested date or trigger]

--- a/templates/standard-project/.claude/skills/spike/SKILL.md
+++ b/templates/standard-project/.claude/skills/spike/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: spike
+description: >-
+  Time-boxed technical spike: define success criteria, build the minimum to
+  answer "can it work?", document evidence in spike-learnings.md, and commit.
+  Use when the user invokes /spike or wants hands-on validation before larger
+  implementation. Do NOT use for comparing well-documented options or desk
+  research — use research instead.
+disable-model-invocation: true
+---
+
+# Spike
+
+Run a **time-boxed experiment** to validate technical assumptions before
+committing to implementation. A spike **builds something minimal** to prove an
+approach works; research investigates options and practice.
+
+```
+detect paths → questions & criteria → time-boxed build → document learnings → commit
+```
+
+## Templates
+
+| Template | When to use |
+|----------|-------------|
+| `templates/spike-learnings.md` | Always — copy to the target `spike-learnings.md` path, then fill in place |
+
+## Path detection
+
+| Structure | Spike learnings | Spike code (throwaway) |
+|-----------|-----------------|-------------------------|
+| **Dev-infra** | `admin/services/[service]/features/[topic]/spikes/spike-learnings.md` | `.../spikes/` (same feature topic) |
+| **Template** | `docs/maintainers/planning/explorations/[topic]/spike-learnings.md` | `.../explorations/[topic]/spike/` |
+| **Lightweight** | `tests/tmp/explorations/[topic]/spike-learnings.md` | `tests/tmp/explorations/[topic]/spike/` |
+
+**Detection order:** If `admin/services/` exists → dev-infra. Else if `docs/maintainers/planning/explorations/` exists → template. Else → lightweight (gitignored temp).
+
+**Topic:** From `--topic`, `--from-explore [name]`, or explicit user name; normalize to kebab-case, no spaces.
+
+## When to spike vs research
+
+| Situation | Spike | Research |
+|-----------|-------|----------|
+| “Can it even work?” / high technical uncertainty | Yes | |
+| Must exercise real environment (API, cluster, device) | Yes | |
+| Compare documented options or “best practice” | | Yes |
+| Low-risk, well-understood path | | Yes |
+
+If exploration exists, prefer questions flagged **high risk** and viability-shaped (“will it work?”).
+
+## Options
+
+| Invocation | Behavior |
+|------------|----------|
+| `/spike [topic]` | Full flow from questions through learnings |
+| `/spike [topic] --from-explore [explore-topic]` | Load exploration + research-topics for scope |
+| `/spike [topic] --document-learnings` | Skip build; write/update learnings from completed spike |
+| `/spike [topic] --time-box [hours]` | Use explicit hour limit (default 2–4 if unset) |
+| `/spike --dry-run` | Show paths and plan; do not write files |
+| `/spike [topic] --force` | Allow overwriting existing `spike-learnings.md` when policy says stop |
+
+## Workflow
+
+### 1. Identify questions to validate
+
+From exploration (if `--from-explore`) or user prompt, list only questions where:
+
+- The answer must be demonstrated, not read from docs alone.
+- Wrong assumptions would be expensive to unwind.
+
+**Checklist (before criteria):** Each question is falsifiable; edge cases named; links to exploration paths recorded when used.
+
+### 2. Define success criteria (before building)
+
+Display to the user, then ensure the same criteria appear under `## Success Criteria` at the top of the working learnings doc (create from template if new file):
+
+- Each criterion is **testable** (pass/fail or observable behavior).
+- **Time-box** duration is stated (hours).
+
+If `--document-learnings`, synthesize criteria from what was already run only if the user confirms; otherwise focus on filling evidence sections.
+
+### 3. Time-boxed minimal build
+
+- Start timer for agreed hours (`--time-box` or default 2–4).
+- Build **only** what is needed to answer the questions; **no polish**.
+- **When time expires:** stop building and move to documentation — partial results are valid.
+
+Spike code lives under the **Spike code** path for the detected structure. Do **not** treat prototype polish as success.
+
+### 4. Document learnings
+
+Copy `templates/spike-learnings.md` to the resolved `spike-learnings.md` path (unless appending to an existing file per user).
+
+Fill:
+
+- **Questions Answered** — each line cites **evidence** (command output, log, observed behavior).
+- **Key Findings** and **Edge Cases** — no uncited claims.
+- **Go / No-Go** — explicit recommendation + rationale.
+- **Refined Questions** — feed forward to research/exploration.
+
+If `--dry-run`, stop after printing planned paths and criteria.
+
+### 5. Commit
+
+Commit **spike-learnings.md** (and spike code **only** if the user wants it tracked — default is learnings only):
+
+```text
+docs(spike): document [topic] spike learnings
+
+Result: [Validated | Partially Validated | Failed | Pivoted]
+Time-box: [X] hours
+```
+
+## Behavioral Contract
+
+**Criteria before code.** Success criteria appear in the learnings file before substantive implementation work begins. If criteria change mid-spike, record the change and why — **observable**, **delta-only**.
+
+**Hard stop at time-box.** When the timer boundary is hit, **stop** building and document what was proven, disproven, or unknown — **bounded**, **failure-aware** (partial is allowed).
+
+**Throwaway scope.** Prefer deleting or ignoring polish; the artifact of record is `spike-learnings.md`, not prettified prototype — **outcome-framed**.
+
+**Evidence, not opinions.** Every finding references an observation the reader could reproduce or inspect (error text, metric, screenshot reference, command) — **observable**, **outcome-framed**.
+
+**Route correctly.** If the user’s need is comparators or literature-style answers, **stop** and point to research — **failure-aware** (wrong workflow).
+
+## Gotchas
+
+**Polishing spike code.** Any time spent on style or extensibility beyond the question is scope creep; capture the urge as a “next step,” not spike work.
+
+**Skipping success criteria.** Starting implementation without written criteria makes Go/No-Go useless — always write criteria first.
+
+**Confusing spike with POC or prototype.** Spikes are hours and throwaway; longer-lived demos belong to different workflows.
+
+**Merging spike and research.** If questions are “what’s best?” or options are already documented, desk research fits better than a spike.
+
+**Forgetting to commit learnings.** Untracked learnings drift — commit the markdown artifact even when spike code is discarded.
+
+**Dry-run still needs clarity.** `--dry-run` should output topic, paths, and planned criteria so reviewers can sanity-check before writes.

--- a/templates/standard-project/.claude/skills/spike/templates/spike-learnings.md
+++ b/templates/standard-project/.claude/skills/spike/templates/spike-learnings.md
@@ -1,0 +1,77 @@
+# Spike Learnings: [Topic Title]
+
+**Exploration:** [path to exploration directory, or N/A for standalone spike]
+**Created:** YYYY-MM-DD
+**Time-box:** [X] hours
+**Result:** [Validated | Partially Validated | Failed | Pivoted]
+
+---
+
+## Success Criteria
+
+- [ ] Criterion 1: [What must be true for this approach to work?]
+- [ ] Criterion 2: [What edge case must be handled?]
+- [ ] Criterion 3: [What performance/behavior is acceptable?]
+
+---
+
+## Questions Answered
+
+- [x] Q1: [Question] — [Answer with evidence]
+- [x] Q2: [Question] — [Answer with evidence]
+- [ ] Q3: [Question] — [Not answered, needs research]
+
+---
+
+## Key Findings
+
+### Finding 1: [Title]
+
+[What we learned. Include specific evidence — error messages, behavior observed, etc.]
+
+### Finding 2: [Title]
+
+[What surprised us or differed from expectations.]
+
+---
+
+## Edge Cases Tested
+
+| Case | Input | Expected | Actual | Pass? |
+|------|-------|----------|--------|-------|
+| [Case 1] | [Input] | [Expected] | [Actual] | Yes/No |
+| [Case 2] | [Input] | [Expected] | [Actual] | Yes/No |
+
+---
+
+## Go / No-Go
+
+**Recommendation:** [Go | No-Go | Go with modifications]
+
+**Rationale:** [Why this approach should or should not be used]
+
+**Modifications needed (if any):**
+- [Modification 1]
+
+---
+
+## Refined Questions
+
+New questions revealed by this spike (feed back to research or exploration):
+
+1. [New question 1]
+
+---
+
+## Spike Code
+
+**Location:** [path to spike/ directory]
+**Keep or discard:** [Keep as reference | Discard | Refactor into implementation]
+
+---
+
+## Next Steps
+
+- [ ] [Next action based on findings]
+- [ ] [Feed refined questions to research if needed]
+- [ ] [Proceed to decision or transition-plan if validated]


### PR DESCRIPTION
## Summary

- Expanded Stage 2 **Group 3** task specs (`tasks/03-standalone-skills.md`) with steps, acceptance criteria, and links to audit artifacts.
- Added **spike command audit** (`artifacts/spike-command-audit.md`): tier classification and time-boxed behavioral contract distilled from `.cursor/commands/spike.md`.
- Added **standalone `spike` skill** with co-located `templates/spike-learnings.md`: path detection, options, workflow, five-property **Behavioral Contract**, and **Gotchas**.
- Added **reflect command audit** (`artifacts/reflect-command-audit.md`): hybrid procedural + synthesis pattern; dev-infra vs template reflection paths.
- Added **standalone `reflect` skill** with `templates/reflection-report.md`: bounded gather/suggest/write flow, dev-infra centralized reflections path, **Behavioral Contract**, and **Gotchas**.
- Updated Stage 2 **implementation-plan** and **status-and-next-steps** (11/15 tasks; Group 3 complete; Group 3 audit links in notes).

## Why

Stage 2 (“Researcher”) must convert **spike** and **reflect** commands to marketplace-style skills using the same standalone pattern as Stage 1 (`int-opp`, `narrative`), with audits and rubric-ready behavioral contracts before Group 4 cutover.

## After Merge

- **Template consumers:** New projects generated from `standard-project` gain `.claude/skills/spike/` and `.claude/skills/reflect/` (commands remain until Group 4 cutover archives them per plan).
- **Maintainers:** Stage 2 planning docs and audit artifacts remain under `planning-stage2/` for Group 4 (install, regression, rubric sweep).
- **No CI workflow or dependency manifest changes** in this PR.

## Follow-ups

- **Group 4:** Install skills, archive `research` / `spike` / `reflect` commands, regression-test `research-conduct`, final five-property sweep, Stage 2 exit criteria (`tasks/04-cutover-and-quality-gate.md`).
- **Deferred (Sourcery):** Generalize reflect skill’s “recent merged PRs” step for non-`gh` environments — **PR88-Overall-#2** in `admin/feedback/deferred-tasks.md`.
- Optional: align any template-learning-project skill layout if that template later gains `.claude/skills/` (currently standard-project only).
