### PR TITLE
chore(group-cycle): clarify Step 0 skip and successor-stage reporting

### DIFF
--- a/.agents/group-cycle.agent.md
+++ b/.agents/group-cycle.agent.md
@@ -16,7 +16,7 @@ questions the agent surfaced during execution.
 | `service` | yes | Service path (e.g., `ai-workflow`) |
 | `base_branch` | no | Branch to base work on (default: `develop`) |
 | `first_group` | no | Set to `true` if this is the first group in a stage (default: `false`) |
-| `prior_pr` | no | PR number of the previous group's merged PR (required if not first_group) |
+| `prior_pr` | no | Merged PR number for Step 0 post-pr closeout. **Omit when** merges are already absorbed on `base_branch` and no sweep is wanted — Step 0 is skipped (**same posture as first dispatch**). Optional `first_group=true` also skips Step 0. If `prior_pr` is omitted, Step 0 is skipped; say why in Step 6. |
 
 ## Skills & Commands
 
@@ -50,9 +50,16 @@ for the human to inspect. The human removes it after merge.
 
 ## Pipeline
 
-### Step 0: Prior Group Closeout (skip if `first_group` is true)
+### Step 0: Prior Group Closeout (skip if no `prior_pr` or `first_group` is true)
 
-Before starting new work, close out the previous group cycle:
+**Skip entirely** when **either** condition holds:
+
+- `first_group` is `true`, **or**
+- `prior_pr` is omitted / empty (human treats merges as already reflected on `base_branch`; behaves like **first dispatch** for closeout purposes).
+
+Do **not** block, warn, or loop on “missing prior PR” — just skip Step 0 and proceed to Step 1.
+
+When **not skipped**, close out before new work begins:
 
 1. **Post-PR:** Read `.cursor/commands/post-pr.md` and follow it for the prior
    group's merged PR (`prior_pr`). Key outputs: status document updates,
@@ -219,7 +226,13 @@ fabricate questions to fill the template.
 
 ### Step 6: Report
 
-Present a summary to the human:
+Compose the summary from execution facts. Include:
+
+**Step 0:** State whether Step 0 ran (for `#prior_pr`) or was skipped (first group or no `prior_pr`).
+
+**Stage boundary:** If `implementation-plan.md` marks **every task `[x]`** for the current stage and **no successor planning directory** exists for this feature (e.g. no `planning-stageN+1/`), that is **not** a defect — cycle is complete for this scope. Add **one optional** Needs Human Attention bullet — *when ready,* create successor planning (`transition-plan` / new tasks) before next `/agent-dispatch`. Never fail the pipeline for missing successor plans.
+
+Present the summary to the human using this shape:
 
 ```
 ## Group Cycle Complete: [Group Name]


### PR DESCRIPTION
## Summary

- Clarifies **`prior_pr`**: omit it when prior merges are already on the base branch and no Step 0 sweep is needed—**same skip posture as first dispatch**—and document that choice in Step 6.
- **Step 0** is skipped when either `first_group` is true **or** `prior_pr` is omitted/empty; agents must **not** block, warn, or loop on a missing prior PR.
- **Step 6** must state whether Step 0 ran (with `prior_pr`) or was skipped.
- **Stage boundary**: if every task in the current stage is complete and there is **no** successor planning directory (e.g. no `planning-stageN+1/`), that is **not** a defect; the report may optionally remind humans to add successor planning before the next `/agent-dispatch`, but the pipeline must **never** fail for missing successor plans alone.

## Why

Runs often start when `develop` already reflects prior work, so treating omitted `prior_pr` like first dispatch avoids redundant post-PR/pre-phase churn. Explicit stage-boundary wording prevents false “failure” interpretations when a stage is done but successor planning has not been created yet.

## After Merge

No downstream effects — **docs-only** (`.agents/group-cycle.agent.md`). Updated semantics apply the next time the group-cycle agent doc is followed.

## Follow-ups

- Optional: create GitHub labels `group-cycle-meta` and `housekeeping` if you want them on this class of PRs (CLI label add failed — labels not present in the repo).

## Summary by Sourcery

Clarify group-cycle agent documentation around when to skip prior group closeout (Step 0) and how to report stage completion and successor planning in the final summary.

Documentation:
- Document that omitting `prior_pr` (or setting `first_group=true`) skips Step 0 and should not cause blocking or warnings.
- Update Step 6 reporting requirements to explicitly state whether Step 0 ran and to treat missing successor planning as non-fatal while optionally nudging humans to add it.