### PR TITLE
feat(agentic-workflow-modernization): Decision Skill (Group 1)

### DIFF
--- a/admin/feedback/sourcery/pr92.md
+++ b/admin/feedback/sourcery/pr92.md
@@ -1,0 +1,20 @@
+# Sourcery review — PR #92
+
+**PR:** https://github.com/grimm00/dev-infra/pull/92  
+**Fetched:** 2026-05-02  
+**Tool:** `dt-review 92` — parser reported no markdown review body; Sourcery bot message was boilerplate approval (“changes … look great”) with no per-file findings.
+
+---
+
+## Priority matrix
+
+| # | Comment / finding | Priority | Impact | Effort | Action |
+|---|-------------------|----------|--------|--------|--------|
+| — | No actionable review items extracted | — | — | — | N/A |
+
+---
+
+## Notes
+
+- GitHub check **Sourcery review**: pass.
+- If structured comments appear later on the PR, re-run `dt-review` or append rows above.

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/artifacts/decision-command-audit.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/artifacts/decision-command-audit.md
@@ -1,0 +1,87 @@
+# Audit: `decision` command → skill conversion
+
+**Source:** `.cursor/commands/decision.md` (632 lines)  
+**Feature:** agentic-workflow-modernization / Stage 3 Group 1  
+**Date:** 2026-05-02  
+**Tier definitions:** ADR-004 — Tier 1 precise, Tier 2 mixed (rewrite for five-property rubric), Tier 3 vague/problematic (rewrite or remove).
+
+---
+
+## Executive summary
+
+| Finding | Detail |
+|---------|--------|
+| Interview gap | The command text does **not** describe a pre-decision human interview. The interview pattern lives in project research (`decisions/decision-interview.md`) and design/staging intent (ADR-001: decision = hybrid + interview). The skill must **add** Workflow step 0 explicitly. |
+| Path inconsistency | **Configuration** (lines 13–16) claims Dev-Infra decisions live under `admin/decisions/[topic]/`, while **Step 3** and **Reference** (617–618) use `admin/services/[service]/features/[topic]/decisions/`. The skill should treat **Step 3 + Reference** as canonical for dev-infra feature decisions. |
+| Commit workflow | Step 7 prescribes a full docs-branch merge to `develop`. That is **Tier 3** for a portable template skill: violates bounded/outcome framing for arbitrary repos. Skill should give **commit message shape + stop**, not enforce internal dev-infra git policy. |
+| Hybrid split | Steps 1–2 are judgment-heavy (decision point identification) → **Behavioral contract**. Steps 3–6 are template/file scaffolding → **Workflow**. ADR-004 § “Separate workflow from behavioral contract” applies. |
+
+---
+
+## Section-by-section classification
+
+| Location / topic | Tier | Rationale (rubric sketch) | Skill action |
+|------------------|------|---------------------------|--------------|
+| Title + tagline | 1 | Observable output (ADRs) | Keep |
+| Path Detection — Dev-Infra (admin/decisions…) | **3** | Conflicts with later steps; unobservable “which repo shape” without correction | **Replace** with canonical `admin/services/[service]/features/[topic]/decisions/` |
+| Path Detection — template / project-wide | 1 | Clear paths | Keep |
+| Topic detection (`--topic`, sanitize) | 2 | Bounded if flags documented | Keep, clarify |
+| Workflow overview diagram | 2 | Omits interview; “Identifies decision points” under-specified | Extend in skill |
+| Usage / options | 1 | | Keep |
+| Step 1 — Identify research source | 1 | Clear file globs and checklists | Keep |
+| Step 2 — Identify decision points | 2 | Open-ended questions; needs observable outputs in skill | Rewrite in behavioral contract |
+| Step 3 — Create decisions hub | 2 | Template-heavy Tier 1; location auto-detect **contradicts** Configuration | Unify paths; keep structure |
+| Step 4 — Create ADR documents | 1 | Section template is explicit | Keep as checklist of required ADR headings |
+| Step 5 — decisions-summary | 1 | | Keep |
+| Step 6 — Update parent decisions README | 2 | dev-infra vs template paths differ (`admin/decisions/README.md` vs `docs/...`) | Keep with resolution table |
+| Step 7 — Commit and push | **3** | Assumes docs-only branch workflow + merge to `develop` | Replace with “suggest commit; follow project policy” |
+| Integration / scenarios / tips | 2 | Useful but some references `/transition-plan` only | Neutral “planning handoff” wording |
+| Reference/footer | 1 | Paths match Step 3 for dev-infra | Keep canonical row as single source of truth |
+
+---
+
+## Consolidated tier tallies (behavioral + procedural chunks)
+
+| Tier | Count (approx. blocks) | Notes |
+|------|------------------------|-------|
+| Tier 1 | 14 | Path tables (corrected), file templates, checklists, usage |
+| Tier 2 | 8 | Decision-point extraction, tips, integration narrative |
+| Tier 3 | 3 | Wrong dev-infra root in Configuration; prescriptive merge-to-develop; optional ambiguity on “auto-detect from research source” without stop condition |
+
+---
+
+## Interview workflow (external to command text)
+
+**Source:** `admin/services/ai-workflow/features/agentic-workflow-modernization/decisions/decision-interview.md`
+
+| Element | Role in skill |
+|---------|----------------|
+| “How to Use This File” | Sets tone: short answers, skip ok, no wrong answers — encode as **stop / resume** behavior |
+| Section 1 UX priorities | Surfaces command usage / friction **before** technical ADR drafting |
+| Section 2+ constraints / instincts | Shapes **ordering** of decision clusters and acceptable tradeoffs |
+| Pattern | **Phase start signal** (named in narrative.md): skill reads or scaffolds `decision-interview.md` adjacent to topic hub before heavy analysis |
+
+---
+
+## Five-property check (command-wide)
+
+| Property | Pass? | Gap |
+|----------|-------|-----|
+| Observable | Partial | “Identify decision points” needs concrete outputs listed |
+| Bounded | Partial | No explicit stop when research missing; Step 7 unbounded git process |
+| Outcome-framed | Mostly | Templates are outcome-framed; meta-instructions sometimes persona-like |
+| Delta-only | Partial | Long duplicated markdown samples — skill should reference structure not paste 400 lines |
+| Failure-aware | Weak | Little on conflicting path rules or empty research |
+
+---
+
+## Skill design decisions (from audit)
+
+1. **Single SKILL.md** under 500 lines: summarize ADR/hub templates by section list + one short example block, not full paste.
+2. **Interview** is mandatory path with escape hatch: user may type explicit waiver (“proceed without interview”).
+3. **Options-not-answers:** align with decision-science refactor narrative; behavioral contract enforces 2–3 alternatives before recording a Decision section.
+4. **Planning handoff:** mention `write-plan` / transition-plan as a **separate** invocation after ADRs (template may not have write-plan until Group 2 — use neutral “planning skill or project convention”).
+
+---
+
+**Last Updated:** 2026-05-02

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/implementation-plan.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/implementation-plan.md
@@ -21,7 +21,7 @@ tasks_files:
 ---
 # Implementation Plan — Stage 3: Planner (Agentic Workflow Modernization)
 
-**Status:** 🔴 Not Started
+**Status:** 🟠 In Progress
 **Created:** 2026-05-02
 **Last Updated:** 2026-05-02
 **Source:** [ADRs 1-5 + design.md Section 5](../decisions/) → Stage 3 of 4-stage v1
@@ -58,9 +58,9 @@ Convert the **Planner** role group of dev-infra commands to skills. This stage c
 ## 📝 Implementation Plan
 
 ### Decision Skill
-- [ ] Task 1: Audit decision command and classify behavioral instructions
-- [ ] Task 2: Design decision SKILL.md (interview workflow + ADR behavioral contract)
-- [ ] Task 3: Validate decision skill against a recent ADR produced under the command
+- [x] Task 1: Audit decision command and classify behavioral instructions
+- [x] Task 2: Design decision SKILL.md (interview workflow + ADR behavioral contract)
+- [x] Task 3: Validate decision skill against a recent ADR produced under the command
 
 ### Write-Plan Skill
 - [ ] Task 4: Audit transition-plan command modes and classify behavioral instructions
@@ -81,7 +81,7 @@ Convert the **Planner** role group of dev-infra commands to skills. This stage c
 
 ## ✅ Definition of Done
 
-- [ ] decision skill exists with interview workflow and ADR behavioral contract
+- [x] decision skill exists with interview workflow and ADR behavioral contract
 - [ ] write-plan decomposition decided and implemented (single or family)
 - [ ] plan-review skill exists with staged-planning path support
 - [ ] All skills pass five-property rubric with populated gotchas

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/status-and-next-steps.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/status-and-next-steps.md
@@ -1,17 +1,17 @@
 # Status & Next Steps — Stage 3: Planner
 
-**Status:** 🔴 Not Started
+**Status:** 🟠 In Progress
 **Last Updated:** 2026-05-02
 
 ---
 
 ## 📊 Progress Summary
 
-**Overall:** 0/12 tasks complete
+**Overall:** 3/12 tasks complete
 
 | Group | Status | Progress | Notes |
 |-------|--------|----------|-------|
-| Decision Skill | 🔴 Not Started | 0/3 tasks | Audit, convert (interview + ADR contract), validate |
+| Decision Skill | ✅ Active/Complete | 3/3 tasks | Audit artifact, `decision/SKILL.md`, validation GO |
 | Write-Plan Skill | 🔴 Not Started | 0/4 tasks | Audit, decomposition decision, convert, validate |
 | Plan-Review Skill | 🔴 Not Started | 0/2 tasks | Audit, convert (staged-planning path support) |
 | Cutover and Quality Gate | 🔴 Not Started | 0/3 tasks | Install, rubric sweep, exit criteria |
@@ -20,7 +20,7 @@
 
 ## 🚀 Next Steps
 
-1. **Group 1** — decision skill: audit command (632 lines), design interview workflow, validate against recent ADR
+1. **Group 2** — write-plan skill: audit `transition-plan`, decomposition, convert, validate against Stage 3 scaffolding
 
 ---
 

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/tasks/01-decision-skill.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/tasks/01-decision-skill.md
@@ -30,7 +30,7 @@
   - **Files:** `templates/standard-project/.claude/skills/decision/SKILL.md` (create)
   - **Acceptance:** Skill is self-contained (FR-8): core flow readable without external commands; interview + ADR contract present; rubric-aligned prose.
 
-- [ ] Task 3: Validate decision skill against a recent ADR produced under the command
+- [x] Task 3: Validate decision skill against a recent ADR produced under the command
   - **Purpose:** Static regression vs command-era ADR shape.
   - **Steps:**
     1. Read `admin/services/ai-workflow/features/agentic-workflow-modernization/decisions/adr-001-v1-skill-selection.md`.
@@ -54,7 +54,7 @@
 - [x] Audit artifact produced with tier classification
 - [x] decision SKILL.md in templates with interview workflow + ADR contract
 - [x] Five-property rubric passes, gotchas populated
-- [ ] Validation log with go/no-go verdict
+- [x] Validation log with go/no-go verdict
 
 > **Follow-up (Group 2 or cutover):** Extract inline templates (ADR template, hub README, decision-interview scaffold) into `assets/` and add `references/structure.yaml` per the convention established in Group 2. The decision skill was converted before this convention was defined.
 
@@ -62,18 +62,24 @@
 
 ## 📋 Validation Log
 
-**Date:** _(Task 3)_  
+**Date:** 2026-05-02  
 **Reference ADR:** `decisions/adr-001-v1-skill-selection.md`
 
 | ADR section | Required by skill? | Present in ADR-001? | Notes |
 |-------------|-------------------|---------------------|-------|
-| _(pending)_ | | | |
+| Context | yes | yes | Skill §4 requires Context + research links; ADR-001 matches. |
+| Decision | yes | yes | |
+| Consequences | yes | yes | ADR uses Positive/Negative lists; skill expects same shape. |
+| Alternatives Considered | yes | yes | Two labeled alternatives (A/B) with why-not-chosen. |
+| Decision Rationale | yes | partial | No `## Decision Rationale` heading; rationale is embedded in **Decision** and **Context** — acceptable if substance is present; skill still recommends dedicated heading. |
+| Requirements Impact | yes | yes | |
+| References | yes | yes | |
 
-**Interview coverage:** _(pending)_
+**Interview coverage:** Skill Workflow §0 maps to `decision-interview.md` (priorities → rationale / ordering). ADR-001 text reflects interview-derived scope (e.g. C1-1, staged roles); static check only.
 
-**Verdict:** _(pending)_
+**Verdict:** GO
 
-**Rationale:** _(pending)_
+**Rationale:** ADR-001 satisfies the skill’s required ADR headings except a dedicated Decision Rationale section (substance present elsewhere). Interview-first step closes the legacy command gap. Live topic run still recommended; no NO-GO blockers for this group deliverable.
 
 ---
 

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/tasks/01-decision-skill.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/tasks/01-decision-skill.md
@@ -2,30 +2,43 @@
 
 **Feature:** Agentic Workflow Modernization (Stage 3: Planner)
 **Group:** Decision Skill
-**Status:** 🔴 Scaffolding (needs expansion)
+**Status:** ✅ Expanded
 **Last Updated:** 2026-05-02
 
 ---
 
 ## 📝 Tasks
 
-> ⚠️ **Scaffolding:** Run `/write-plan agentic-workflow-modernization --expand --group 1` to add detailed implementation notes.
-
-- [ ] Task 1: Audit decision command and classify behavioral instructions
-  - Read `.cursor/commands/decision.md` (632 lines) and classify every instruction against the three precision tiers (Tier 1/2/3)
-  - Identify the interview workflow structure: question sequence, ADR template filling, decision-interview.md pattern
-  - Produce audit artifact at `planning-stage3/artifacts/decision-command-audit.md`
+- [x] Task 1: Audit decision command and classify behavioral instructions
+  - **Purpose:** Map `.cursor/commands/decision.md` to ADR-004 tiers before conversion so nothing vague ships in the skill.
+  - **Steps:**
+    1. Read `decision.md` end-to-end; note path-detection contradictions (Configuration vs Step 3 vs Reference).
+    2. Classify each major section and standout instruction as Tier 1 (precise), Tier 2 (mixed), or Tier 3 (vague/problematic) per Topic 8 / ADR-004.
+    3. Record interview workflow separately: current command does **not** encode interview-first prose — pull structure from `decisions/decision-interview.md` and design staging notes (Stage 3 Planner).
+    4. Write `planning-stage3/artifacts/decision-command-audit.md` with summary table, tier tallies, and “skill actions” (keep / rewrite / omit).
+  - **Files:** `planning-stage3/artifacts/decision-command-audit.md` (create)
+  - **Acceptance:** Artifact exists; every command section ≥ summary row; explicit note on interview gap and canonical dev-infra decisions path.
 
 - [ ] Task 2: Design decision SKILL.md (interview workflow + ADR behavioral contract)
-  - Hybrid skill: procedural interview flow + behavioral contract for ADR quality
-  - Bake in the interview pattern from this feature's own research (design.md Section 5 calls this out)
-  - Apply five-property rubric to all behavioral instructions; populate gotchas
-  - Install in `templates/standard-project/.claude/skills/decision/SKILL.md`
+  - **Purpose:** Ship hybrid skill: human interview preflight + procedural ADR scaffolding + behavioral ADR quality bar.
+  - **Steps:**
+    1. Add `templates/standard-project/.claude/skills/decision/SKILL.md` with YAML frontmatter (`name`, `description`, `disable-model-invocation: true`).
+    2. **Workflow:** (0) Decision interview — locate or scaffold `decision-interview.md` under the topic decisions tree; **stop** until human fills priority sections or explicitly waives in chat; (1) research/requirements reads per path table; (2) decision points with **options-not-answers** (2–3 alternatives, tradeoffs, no premature recommendation); (3) hub README; (4) one ADR per decision point using template sections; (5) decisions-summary; (6) update parent decisions README quick links when present; (7) commit guidance **bounded** to project norms (do not require merge-to-develop like the command).
+    3. **Behavioral contract:** Observable outputs (filenames, sections), bounded stop conditions, outcome-framed ADR structure, delta-only path rules (fix dev-infra `admin/services/.../decisions/`), failure-aware (missing research, missing interview waiver, ambiguous topic).
+    4. **Gotchas:** ≥5 bullets from audit Tier 3/mixed items and path confusion.
+    5. Keep `SKILL.md` under 500 lines (ADR-004).
+  - **Files:** `templates/standard-project/.claude/skills/decision/SKILL.md` (create)
+  - **Acceptance:** Skill is self-contained (FR-8): core flow readable without external commands; interview + ADR contract present; rubric-aligned prose.
 
 - [ ] Task 3: Validate decision skill against a recent ADR produced under the command
-  - Static comparison: behavioral coverage, interview flow, ADR quality output
-  - Reference artifact: one of ADR-001 through ADR-005 (produced under command era)
-  - Document go/no-go verdict in task file's Validation Log
+  - **Purpose:** Static regression vs command-era ADR shape.
+  - **Steps:**
+    1. Read `admin/services/ai-workflow/features/agentic-workflow-modernization/decisions/adr-001-v1-skill-selection.md`.
+    2. Checklist map: Context, Decision, Consequences (+ pos/neg), Alternatives Considered (≥2), Decision Rationale, Requirements Impact, References — skill workflow requires each in ADR output.
+    3. Compare interview intent: skill step 0 must reference the same priority surfaces as `decision-interview.md` (Sections 1–3 style), not necessarily verbatim text.
+    4. Record **Validation Log** below with **Verdict:** `GO` or `NO-GO` + rationale.
+  - **Files:** This task file (Validation Log section)
+  - **Acceptance:** Log contains checklist results and a clear GO/NO-GO.
 
 ---
 
@@ -38,12 +51,29 @@
 
 ## ✅ Completion Criteria
 
-- [ ] Audit artifact produced with tier classification
+- [x] Audit artifact produced with tier classification
 - [ ] decision SKILL.md in templates with interview workflow + ADR contract
 - [ ] Five-property rubric passes, gotchas populated
 - [ ] Validation log with go/no-go verdict
 
 > **Follow-up (Group 2 or cutover):** Extract inline templates (ADR template, hub README, decision-interview scaffold) into `assets/` and add `references/structure.yaml` per the convention established in Group 2. The decision skill was converted before this convention was defined.
+
+---
+
+## 📋 Validation Log
+
+**Date:** _(Task 3)_  
+**Reference ADR:** `decisions/adr-001-v1-skill-selection.md`
+
+| ADR section | Required by skill? | Present in ADR-001? | Notes |
+|-------------|-------------------|---------------------|-------|
+| _(pending)_ | | | |
+
+**Interview coverage:** _(pending)_
+
+**Verdict:** _(pending)_
+
+**Rationale:** _(pending)_
 
 ---
 

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/tasks/01-decision-skill.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/tasks/01-decision-skill.md
@@ -19,7 +19,7 @@
   - **Files:** `planning-stage3/artifacts/decision-command-audit.md` (create)
   - **Acceptance:** Artifact exists; every command section ≥ summary row; explicit note on interview gap and canonical dev-infra decisions path.
 
-- [ ] Task 2: Design decision SKILL.md (interview workflow + ADR behavioral contract)
+- [x] Task 2: Design decision SKILL.md (interview workflow + ADR behavioral contract)
   - **Purpose:** Ship hybrid skill: human interview preflight + procedural ADR scaffolding + behavioral ADR quality bar.
   - **Steps:**
     1. Add `templates/standard-project/.claude/skills/decision/SKILL.md` with YAML frontmatter (`name`, `description`, `disable-model-invocation: true`).
@@ -52,8 +52,8 @@
 ## ✅ Completion Criteria
 
 - [x] Audit artifact produced with tier classification
-- [ ] decision SKILL.md in templates with interview workflow + ADR contract
-- [ ] Five-property rubric passes, gotchas populated
+- [x] decision SKILL.md in templates with interview workflow + ADR contract
+- [x] Five-property rubric passes, gotchas populated
 - [ ] Validation log with go/no-go verdict
 
 > **Follow-up (Group 2 or cutover):** Extract inline templates (ADR template, hub README, decision-interview scaffold) into `assets/` and add `references/structure.yaml` per the convention established in Group 2. The decision skill was converted before this convention was defined.

--- a/templates/standard-project/.claude/skills/decision/SKILL.md
+++ b/templates/standard-project/.claude/skills/decision/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: decision
+description: >-
+  Create Architecture Decision Records from research: human decision-interview
+  first, then one ADR per decision point with alternatives and rationale.
+  Use after research is complete and the user wants /decision or to record
+  topic decisions. Do NOT run planning/task implementation in this skill —
+  hand off to the project's planning workflow after ADRs exist.
+disable-model-invocation: true
+---
+
+# Decision
+
+Make **documented architecture decisions** from research artifacts. **Hybrid
+skill:** procedural file scaffolding + behavioral judgment (decision framing,
+alternative quality, human pacing).
+
+**North star:** The user stays in control and enriched by slowing down — not
+rushed to a single “right answer” before priorities are explicit (see
+decision-interview pattern).
+
+---
+
+## When to use
+
+- Research outputs exist (summary + topic docs or equivalent) and the user
+  wants ADRs for a topic.
+- User says `/decision`, “decision command”, or “turn this research into ADRs”.
+
+## When not to use
+
+- Research scaffolding is missing → point to **research-setup** first.
+- User only wants brainstorming without records → **discuss**.
+- User wants implementation tasks → **task** / planning pipeline, not this skill.
+
+---
+
+## Path resolution
+
+Pick **one** row and use it consistently for `topic` (kebab-case slug):
+
+| Structure | Topic root | Decisions directory | Research summary (typical) | Requirements (typical) |
+|-----------|------------|--------------------|----------------------------|-------------------------|
+| Dev-Infra feature | `admin/services/[service]/features/[topic]/` | `[topic-root]/decisions/` | `research/research-summary.md` or under `research/` | `[topic-root]/requirements.md` or `research/requirements.md` |
+| Template maintainer | `docs/maintainers/` | `docs/maintainers/decisions/[topic]/` | `docs/maintainers/research/[topic]/research-summary.md` | `docs/maintainers/research/[topic]/requirements.md` |
+| Project-wide | `docs/maintainers/` | `docs/maintainers/decisions/[topic]/` | same as template row | same as template row |
+
+**Do not** use `admin/decisions/[topic]/` for dev-infra feature work — that path
+conflicts with feature-local hubs; feature **`[topic]/decisions/`** is canonical.
+
+---
+
+## Preconditions (stop if unmet)
+
+1. User supplies or confirms `topic` and at least one research path to read
+   (`--from-research` equivalent).
+2. After reading: if there are **no** findings and **no** stated decision
+   questions, **stop** — research is not ready.
+
+---
+
+## Workflow
+
+### 0. Decision interview (human priorities)
+
+**Goal:** Surface priorities, friction, and constraints **before** clustering
+decision points (phase start signal from agentic-workflow research).
+
+1. Compute `decisions/` directory for the topic from the table above.
+2. Interview artifact path: **`[decisions-dir]/decision-interview.md`**.
+3. If the file **does not exist**: offer to create a stub with sections modeled
+   on typical interview flow:
+   - **How to use** (short answers; skip ok)
+   - **User experience priorities** (which workflows matter; friction)
+   - **Constraints / instincts** (scope, risk, “v1 means…”)
+   - Optional: **architecture / validation** prompts  
+   Then **stop** until the user fills enough to guide clustering **or** types an
+   explicit in-chat waiver: e.g. `waive decision interview`.
+4. If the file **exists**: read it first; use it to order which decision clusters
+   to tackle and what tradeoffs are acceptable. If it is still marked awaiting
+   input and empty where it matters, **stop** and ask the user to complete or
+   waive.
+
+### 1. Load research and requirements
+
+1. Read `research-summary.md` (or equivalent) for the topic.
+2. Read per-topic research files linked from the hub or under `research/`.
+3. Read `requirements.md` when present (functional + non-functional).
+4. **Outputs:** mental model of constraints, findings, and candidate requirements
+   IDs to reference later.
+
+### 2. Identify decision points (cluster)
+
+For each cluster of related unknowns:
+
+1. Name **one** decision question (one ADR per decision point later).
+2. List **2–3 alternatives** with **pros/cons** — **do not** present a single
+   recommended winner until the user chooses or defers (see Behavioral
+   Contract).
+3. Note decision criteria (e.g. portability, complexity, team size).
+
+**Observable output:** Ordered list of decision points (titles only) shown to
+the user; User confirms order or edits before file writes.
+
+### 3. Create or update decisions hub README
+
+In `[decisions-dir]/README.md`:
+
+- Purpose: decisions hub for topic; links to research + requirements.
+- Table listing each ADR with status (Proposed until user accepts).
+- `decisions-summary.md` link.
+
+Use the project's status emoji conventions if already present; otherwise 🔴 /
+🟡 / ✅ as in existing docs.
+
+### 4. Write ADRs (one file per decision point)
+
+**Filename:** `adr-[NNN]-[kebab-name].md` in `[decisions-dir]/`,
+zero-padded numbering matching hub order.
+
+**Required sections (non-negotiable):**
+
+1. **Context** — problem, forces, links to research + requirements.
+2. **Decision** — clear decision statement.
+3. **Consequences** — Positive and Negative subsections.
+4. **Alternatives Considered** — at least two, each with pros/cons and **why not
+   chosen** (or “deferred” with reason).
+5. **Decision Rationale** — ties back to interview priorities and research.
+6. **Requirements Impact** — affected/refined requirements.
+7. **References** — research paths, interview file if used.
+
+**Status:** start as **Proposed** unless the user directs otherwise.
+
+### 5. Create `decisions-summary.md`
+
+Summarize each ADR in one screen: decision one-liner, status, link. Requirements
+impact at high level, pointer to full `requirements.md`.
+
+### 6. Update parent decisions index (if present)
+
+| Structure | Parent index |
+|-----------|----------------|
+| Template / project-wide | `docs/maintainers/decisions/README.md` |
+| Dev-Infra | `admin/decisions/README.md` **or** service hub if that is where the repo lists decision topics — use whichever file already lists other topics. If none exists, skip (do not invent org-wide policy). |
+
+Add the topic link only if that file exists and is the established pattern.
+
+### 7. Commit guidance (bounded)
+
+1. Propose a single commit or small series with message shape:
+   `docs(decisions): add [topic] ADRs` (or per-ADR if user prefers).
+2. List `git add` paths concretely.
+3. **Stop.** Do not merge to a branch unless the user's repository policy asks —
+   the old command's merge-to-develop flow is not universal.
+
+---
+
+## Behavioral Contract
+
+**Options, not answers.** Until the user selects or explicitly defers, present
+**2–3** credible alternatives with tradeoffs for each decision point. A
+recommended default is allowed **only** if the user asks for a recommendation
+after seeing alternatives.
+
+**One ADR per decision point.** Do not combine unrelated decisions in one ADR.
+
+**Traceability.** Each ADR's Context and References must include paths the reader
+can open — no orphan decisions.
+
+**Interview informs rationale.** The `decision-interview.md` content (or waiver)
+must visibly influence **Decision Rationale** and ordering — if not, you skipped
+the point of step 0.
+
+**Bounded analysis.** Enough analysis to distinguish alternatives; stop when
+sections are complete and consistent. Do not continue into implementation
+planning.
+
+**Failure-aware.** If paths conflict or hub already exists with different
+numbering, **pause** and ask whether to append, renumber, or align with existing
+ADRs.
+
+---
+
+## Gotchas
+
+**Wrong dev-infra root.** Using a global `admin/decisions/[topic]/` path for
+feature work breaks links; use `admin/services/.../features/[topic]/decisions/`.
+
+**Skipping interview silently.** Without priorities, decision order defaults to
+technical completeness — that violates the interview-first pattern; only proceed
+with an explicit waiver.
+
+**Single-option ADRs.** An ADR with one “alternative” is incomplete — fold more
+options in or document why others were eliminated in research.
+
+**Paste-only ADRs.** Filling the template with placeholders and lorem-style
+text — each section needs substantive ties to **this** topic's research.
+
+**Merged recommendations.** If you “hallucinate” a decision the user did not
+accept, rewind: alternatives first, then record their choice.
+
+**Planning bleed.** Do not create `implementation-plan.md` here — that belongs
+to the planning / write-plan step after ADRs stabilize.
+
+---
+
+**Last Updated:** 2026-05-02


### PR DESCRIPTION
## Summary

- **Audit** the `decision` command (632 lines) and produce a tiered classification artifact (`decision-command-audit.md`) identifying interview gaps, path inconsistencies, and the hybrid split between workflow and behavioral contract
- **Create** the `decision` SKILL.md in `templates/standard-project/.claude/skills/decision/` — a hybrid skill with interview-first workflow (Step 0 decision-interview + waiver), path resolution table, ADR scaffolding, behavioral contract (options-not-answers), and populated gotchas (~207 lines)
- **Validate** the decision skill against `adr-001` with a GO verdict (partial match on Decision Rationale heading noted)
- **Update** Stage 3 planning docs: implementation plan (3/10 tasks complete, Group 1 done), status-and-next-steps, and cutover task file — all reflecting plan-review deferral and renumbering to 3 groups / 10 tasks
- **Remove** `03-plan-review-skill.md` task file (plan-review deferred to future cycle)
- **Rename** cutover task file from `04-` to `03-` and renumber tasks 10–12 → 8–10

## Why

Stage 3 of the agentic-workflow-modernization converts the Planner role group from `.cursor/commands/` to `.claude/skills/`. This is Group 1 — the `decision` skill — which is the first hybrid skill with a structured human-interview workflow baked in. The interview-first pattern (from the feature's own research) is being encoded for the first time at the skill level.

## After Merge

- New template file `templates/standard-project/.claude/skills/decision/SKILL.md` will ship with the next project generation via `new-project.sh` — new projects will get the decision skill out of the box
- `planning-stage3/tasks/03-plan-review-skill.md` is deleted; the plan-review command remains a live `.cursor/commands/` file (not archived)
- Cutover task file renumbered (`04-` → `03-`); future `/agent-dispatch` for Group 3 should reference `03-cutover-and-quality-gate.md`

## Follow-ups

- Group 2 (write-plan skill) is next — decomposition question (single vs family) to be resolved during audit
- Validation noted Decision Rationale heading is only partially matched as a dedicated ADR section — may want to tighten the rubric check in a future pass
- `dt-review` could not parse structured Sourcery findings for this PR (boilerplate-only body) — no actionable items deferred
