### PR TITLE
feat(agentic-workflow-modernization): Write-Plan Skill (Group 2)

### DIFF
--- a/admin/feedback/sourcery/pr93.md
+++ b/admin/feedback/sourcery/pr93.md
@@ -1,0 +1,136 @@
+# Sourcery Review Analysis
+**PR**: #93
+**Repository**: grimm00/dev-infra
+**Generated**: Sat May  2 21:33:33 CDT 2026
+
+---
+
+## Summary
+
+Total Individual Comments: 3
+
+## Individual Comments
+
+### Comment #1
+
+**Type**: question
+
+**Description**: Tools consuming this schema may need a clearer contract for `{N}` (e.g., must it be a positive integer, is it 1-based, are zero-padded or non-numeric values allowed?). Please briefly specify the expected format (e.g., `1`, `2`, `3`) so automation can reliably generate and discover staged directories.
+
+<details>
+<summary>Details</summary>
+
+<b>Code Context</b>
+
+<pre><code>
++    description: Feature work under admin/services
++    base_glob: &quot;admin/services/{service}/features/{feature}/&quot;
++    default_subdir: planning
++    staged_planning_subdir_pattern: &quot;planning-stage{N}/&quot;
++    notes: Stage 3 of this feature uses planning-stage3/ instead of planning/
++  template_project:
+</code></pre>
+
+<b>Issue</b>
+
+**question:** Clarify how `{N}` in `staged_planning_subdir_pattern` should be instantiated
+
+</details>
+
+---
+
+### Comment #2
+
+**Type**: suggestion
+
+**Description**: Right now it’s unclear how `tasks_files` relates to `groups[*].file` and `groups[*].tasks` (e.g., whether `tasks` indexes into `tasks_files`, or whether `tasks_files` is just a flat list). Consider either structuring `tasks_files` as a list of objects with `file` and `tasks` fields, or explicitly specifying that each `groups[*].file` must match an entry in `tasks_files`, so downstream tooling can reliably validate consistency.
+
+<details>
+<summary>Details</summary>
+
+<b>Code Context</b>
+
+<pre><code>
++
++# Frontmatter contract (must match implementation-plan body checkboxes).
++implementation_plan_frontmatter:
++  required_keys:
++    - task_count
++    - groups
++    - tasks_files
++  group_entry_shape:
++    name: string
++    file: string
++    tasks: list_of_integers
+</code></pre>
+
+<b>Issue</b>
+
+**suggestion:** Tighten the contract between `tasks_files`, group `file`, and `tasks` indices
+
+</details>
+
+---
+
+### Comment #3
+
+**Type**: nitpick (typo)
+
+**Description**: In the phrase `ADR extraction Judgment`, `Judgment` appears mid-sentence; please change it to lowercase (`judgment`) for consistent sentence casing.
+
+<details>
+<summary>Details</summary>
+
+<b>Code Context</b>
+
+<pre><code>
++| Tier | Approx. blocks | Notes |
++|------|----------------|-------|
++| Tier 1 | 28 | Paths, YAML, step checklists, error messages |
++| Tier 2 | 12 | Multi-feature detection, reflection chaining, ADR extraction Judgment |
++| Tier 3 | 2 | Optional: prescriptive “commits with this message” — soften for FR-8 portability |
++
+</code></pre>
+
+<b>Issue</b>
+
+**nitpick (typo):** Fix capitalization of “Judgment” in the Tier 2 notes.
+
+</details>
+
+---
+
+## Priority Matrix Assessment
+
+Use this template to assess each comment:
+
+| Comment | Priority | Impact | Effort | Action |
+|---------|----------|--------|--------|--------|
+| #1 | MEDIUM | MEDIUM | LOW | Clarified `{N}` in `structure.yaml` (1-based integer, `planning-stage` + digits). |
+| #2 | MEDIUM | MEDIUM | LOW | Documented `tasks_files` ↔ `groups[].file` ordering and uniqueness in `structure.yaml`. |
+| #3 | LOW | LOW | LOW | Fixed capitalization in audit tier table (`judgment`). |
+
+### Priority Levels
+- 🔴 **CRITICAL**: Security, stability, or core functionality issues
+- 🟠 **HIGH**: Bug risks or significant maintainability issues
+- 🟡 **MEDIUM**: Code quality and maintainability improvements
+- 🟢 **LOW**: Nice-to-have improvements
+
+### Impact Levels
+- 🔴 **CRITICAL**: Affects core functionality
+- 🟠 **HIGH**: User-facing or significant changes
+- 🟡 **MEDIUM**: Developer experience improvements
+- 🟢 **LOW**: Minor improvements
+
+### Effort Levels
+- 🟢 **LOW**: Simple, quick changes
+- 🟡 **MEDIUM**: Moderate complexity
+- 🟠 **HIGH**: Complex refactoring
+- 🔴 **VERY_HIGH**: Major rewrites
+
+---
+
+## Resolution (in-branch)
+
+- **#1 / #2:** `references/structure.yaml` updated with `{N}` semantics and `tasks_files` consistency rule.
+- **#3:** `transition-plan-command-audit.md` tier table typo fixed.

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/artifacts/transition-plan-command-audit.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/artifacts/transition-plan-command-audit.md
@@ -1,0 +1,122 @@
+# Audit: `transition-plan` command → write-plan skill conversion
+
+**Source:** `.cursor/commands/transition-plan.md` (820 lines)  
+**Feature:** agentic-workflow-modernization / Stage 3 Group 2  
+**Date:** 2026-05-02  
+**Tier definitions:** ADR-004 — Tier 1 precise, Tier 2 mixed (rewrite for five-property rubric), Tier 3 vague/problematic (rewrite or remove).
+
+---
+
+## Executive summary
+
+| Finding | Detail |
+|---------|--------|
+| Two modes | **Setup (default)** scaffolds `implementation-plan.md` + `status-and-next-steps.md` + `tasks/NN-*.md`. **Expand (`--expand`)** adds detail to one group file and flips status Scaffolding → Expanded. |
+| Shared core | Path detection (dev-infra vs template), uniform output contract (frontmatter rules, group file naming), templates for the three output types, error handling, and “related commands” apply to **both** modes. |
+| Mode-specific surface | Setup: source loading (ADR / artifact / reflection), transition typing, grouping extraction, initial commits. Expand: group selection, TDD vs non-TDD guidance, expansion templates, removal of scaffolding banner. |
+| Template-extractable | Large literal markdown **templates** for `implementation-plan.md`, `status-and-next-steps.md`, and group scaffolding (~60–80 lines) — belong in **`assets/`** for the skill; SKILL should reference filenames, not paste hundreds of lines. |
+
+---
+
+## Mode mapping
+
+| Region / topic | Setup | Expand | Shared | Notes |
+|----------------|-------|--------|--------|-------|
+| Configuration — plan path detection | ● | ● | ● | Same output roots for both modes |
+| Workflow overview (Setup vs Expand headers) | ● | ● | | Mode labels differ; both reference same artifacts |
+| Usage / flags | ● heavy | ● subset | ● | `--expand`, `--group`, `--all` only expand |
+| Setup Step 1 — Load source documents | ● | | | ADR vs artifact vs reflection |
+| Setup Step 2 — Determine transition type | ● | | | |
+| Setup Step 3 — Organize into task groups | ● | | | |
+| Setup Step 4–6 — Create plan, status, task files | ● | | | |
+| Setup Step 7 — Commit scaffolding | ● | | | |
+| Expand Step 1 — Identify group(s) | | ● | | |
+| Expand Step 2 — TDD vs non-TDD | | ● | | |
+| Expand Step 3 — Expand task detail | | ● | | |
+| Expand Step 4 — Update group status | | ● | | |
+| Expand Step 5 — Commit | | ● | | |
+| Input source details (ADR / artifact / reflection) | ● | | | Expand reuses *reading* group file only |
+| Release transition type | ● | | | Alters grouping focus, same file shape |
+| Error handling | ● | ● | ● | Different error messages, same categories |
+| Tips / scenarios / related commands | ● | ● | ● | |
+
+---
+
+## Behavioral instruction split (heuristic for decomposition)
+
+**Method:** Count major *instruction-bearing* subsections (numbered steps, checklists, template blocks) as behavioral units; assign each to Setup-only, Expand-only, or Shared (both or neither).
+
+| Bucket | Approx. units | Share of total |
+|--------|---------------|----------------|
+| Shared | Path detection, frontmatter rules, scaffolding/expand templates references, error/tips/related, usage intro | **~38%** |
+| Setup-only | Source load, transition type, group organization, create three file kinds, setup commit | **~40%** |
+| Expand-only | Group identification, TDD routing, expansion patterns, status flip, expand commit | **~22%** |
+
+**Cross-mode dependency:** Expand **requires** Setup outputs (`implementation-plan.md`, group files). That is a **sequential pipeline**, not parallel workflows (contrast **research** family: setup / conduct / consolidate are distinct lifecycles).
+
+**design.md heuristic reinterpretation:** The "below 30% shared → family" rule was meant to detect *independent* modes. Here, shared **contract** (paths, YAML rules, filenames, quality gates) dominates what the agent must hold invariant; mode-specific prose is *which phase of the same plan* is running. Effective **shared behavioral contract** (paths + output schema + tier rules) is **high** (~70%+ of rubric-relevant constraints).
+
+---
+
+## Section-by-section classification
+
+| Location / topic | Tier | Rationale | Skill action |
+|------------------|------|-----------|--------------|
+| Title + two-mode overview | 1 | Clear | Keep; rename to write-plan |
+| Plan path detection | 1 | Tables for dev-infra vs template | Keep; add `planning-stageN/` note for staged plans |
+| Feature detection | 2 | “Prompt user if multiple” — needs stop/default | Clarify bounded behavior |
+| Setup workflow Steps 1–7 | 1–2 | Structured; some open-ended extraction from ADRs | Keep; behavioral contract for “when to stop” |
+| Expand workflow Steps 1–5 | 1–2 | | Keep |
+| `implementation-plan` YAML rules | 1 | | Keep; also live in `references/structure.yaml` |
+| Templates in command (code fences) | 2 | Long — delta-only violation if pasted into SKILL | **Move** bodies to `assets/` |
+| `--from-reflection` “internally calls reflection-artifacts” | 2 | Depends on another command existing | Failure-aware: if no artifact, stop or delegate |
+| Release transition type | 1 | | Keep as branch of Setup |
+| Error handling | 1 | | Keep |
+| Tips / incremental vs `--all` | 1 | | Keep in SKILL Gotchas + workflow |
+
+---
+
+## Template inventory (`assets/` targets)
+
+| Command artifact | Skill path | Role |
+|------------------|------------|------|
+| `implementation-plan.md` template (frontmatter + sections) | `assets/implementation-plan.md` | Copy/adapt per feature |
+| `status-and-next-steps.md` template | `assets/status-and-next-steps.md` | Copy/adapt per feature |
+| Group scaffolding template (~60–80 lines) | `assets/task-group-skeleton.md` | One file per group at setup |
+| Expand-mode task patterns (TDD vs docs vs command) | Inline tables in SKILL or short `assets/expand-patterns.md` (optional) | Kept in SKILL tables to avoid file sprawl |
+
+---
+
+## Consolidated tier tallies
+
+| Tier | Approx. blocks | Notes |
+|------|----------------|-------|
+| Tier 1 | 28 | Paths, YAML, step checklists, error messages |
+| Tier 2 | 12 | Multi-feature detection, reflection chaining, ADR extraction Judgment |
+| Tier 3 | 2 | Optional: prescriptive “commits with this message” — soften for FR-8 portability |
+
+---
+
+## Five-property check (command-wide)
+
+| Property | Pass? | Gap |
+|----------|-------|-----|
+| Observable | Mostly | “Organize into task groups” needs example outputs |
+| Bounded | Mostly | “Prompt to select feature” needs default when unclear |
+| Outcome-framed | Yes | File paths and checkboxes explicit |
+| Delta-only | **Fail** in raw command | Long template fences — **fix** via `assets/` |
+| Failure-aware | Partial | “Already has plan” — covered; weak on missing requirements file |
+
+---
+
+## Decomposition recommendation (for Task 5)
+
+**Recommendation:** **Single `write-plan` skill** with clearly separated **Setup** and **Expand** workflows (same document), plus `assets/` + `references/structure.yaml`.
+
+**Rationale:** Modes are **phases of one capability** (materialize planning tree → deepen one group). A **family** (write-plan-setup / write-plan-expand) would duplicate path detection, frontmatter rules, and structure.yaml unless a parent SKILL held everything — at which point children add little but orchestration friction. Research family differs: conducts are **independently** invokable lifecycles with separate behavioral contracts.
+
+**If evidence later shows teams invoke only “expand” from muscle memory:** optional thin wrapper files could be added in a follow-up; not required for Stage 3.
+
+---
+
+**Last Updated:** 2026-05-02

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/artifacts/transition-plan-command-audit.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/artifacts/transition-plan-command-audit.md
@@ -92,7 +92,7 @@
 | Tier | Approx. blocks | Notes |
 |------|----------------|-------|
 | Tier 1 | 28 | Paths, YAML, step checklists, error messages |
-| Tier 2 | 12 | Multi-feature detection, reflection chaining, ADR extraction Judgment |
+| Tier 2 | 12 | Multi-feature detection, reflection chaining, ADR extraction judgment |
 | Tier 3 | 2 | Optional: prescriptive “commits with this message” — soften for FR-8 portability |
 
 ---

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/implementation-plan.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/implementation-plan.md
@@ -24,7 +24,8 @@ tasks_files:
 **Status:** 🟠 In Progress
 **Created:** 2026-05-02
 **Last Updated:** 2026-05-02
-**Source:** [ADRs 1-5 + design.md Section 5](../decisions/) → Stage 3 of 4-stage v1
+**Source:** [ADRs 1-5 + design.md Section 5](../decisions/) → Stage 3 of 4-stage v1  
+**Group 1 merged:** PR #92 (2026-05-03)
 
 ---
 

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/implementation-plan.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/implementation-plan.md
@@ -31,9 +31,9 @@ tasks_files:
 
 ## 📋 Overview
 
-Convert the **Planner** role group of dev-infra commands to skills. This stage converts decision (632 lines, hybrid with interview pattern), transition-plan (820 lines, two-mode procedural), and plan-review (416 lines, procedural). The open question from design.md — whether transition-plan decomposes into two skills or stays single — is resolved during implementation.
+Convert the **Planner** role group of dev-infra commands to skills. This stage converts decision (632 lines, hybrid with interview pattern), transition-plan (820 lines, **single write-plan skill** with Setup + Expand), and plan-review (416 lines, procedural).
 
-**Skills converted in this stage:** decision, write-plan (possibly write-plan-setup + write-plan-expand), plan-review
+**Skills converted in this stage:** decision, write-plan (single skill; Setup + Expand workflows), plan-review
 **Entry criteria:** Stage 2 go decision (logged ✅ 2026-05-02)
 
 **New convention introduced:** Skills adopt an `assets/` + `references/` directory structure. Template-heavy content (scaffolding files, checklists) lives in `assets/` as copyable files. A `references/structure.yaml` declares the skill's expected I/O shape — input modes, output directories, singleton vs. collection files. This convention is established during write-plan (Group 2) and adopted by all Stage 3 skills.
@@ -41,7 +41,7 @@ Convert the **Planner** role group of dev-infra commands to skills. This stage c
 **Key Changes:**
 
 - decision: hybrid skill — procedural interview workflow + behavioral contract for ADR quality. Bakes in the interview pattern from this feature's own research. Follow-up: extract inline templates into `assets/`.
-- transition-plan → write-plan: largest command (820 lines). Two modes (setup/expand) — assess decomposition vs single skill during audit. **First skill to adopt `assets/` + `references/` convention** (most template-heavy).
+- transition-plan → write-plan: largest command (820 lines); **single skill** with Setup + Expand (Group 2 decision). **First skill to adopt `assets/` + `references/` convention** (most template-heavy).
 - plan-review: procedural review skill — ensures stage plans account for prior learnings and cross-checks consistency. Adopts the new convention.
 - 3 commands archived after conversion (decision, transition-plan, plan-review).
 
@@ -50,7 +50,7 @@ Convert the **Planner** role group of dev-infra commands to skills. This stage c
 ## 🎯 Goals
 
 1. **Convert the interview-pattern skill** — decision is the first skill with a structured human-interview workflow baked in. Validates hybrid encoding at a new level of interactivity.
-2. **Resolve the write-plan decomposition question** — design.md Section 6 defers this to implementation time. The audit decides: single skill (if modes are thin enough) or family (setup + expand).
+2. **Resolve the write-plan decomposition question** — design.md Section 6 deferred to implementation time. **Resolved in Group 2:** single `write-plan` skill (Setup + Expand workflows); see `tasks/02-write-plan-skill.md`.
 3. **Complete the Planner role group** — plan-review rounds out the stage; full thinking pipeline becomes skill-based after merge.
 4. **Apply proven patterns** — Stage 1 and 2 established: five-property rubric, templates-as-assets, family pattern, clean cutover, regression test. Reuse, don't reinvent.
 
@@ -64,10 +64,10 @@ Convert the **Planner** role group of dev-infra commands to skills. This stage c
 - [x] Task 3: Validate decision skill against a recent ADR produced under the command
 
 ### Write-Plan Skill
-- [ ] Task 4: Audit transition-plan command modes and classify behavioral instructions
-- [ ] Task 5: Resolve decomposition — single skill vs family (write-plan-setup + write-plan-expand)
-- [ ] Task 6: Convert transition-plan to write-plan SKILL.md(s) per decomposition decision
-- [ ] Task 7: Validate write-plan skill against Stage 3's own scaffolding (meta-test)
+- [x] Task 4: Audit transition-plan command modes and classify behavioral instructions
+- [x] Task 5: Resolve decomposition — single skill vs family (write-plan-setup + write-plan-expand)
+- [x] Task 6: Convert transition-plan to write-plan SKILL.md(s) per decomposition decision
+- [x] Task 7: Validate write-plan skill against Stage 3's own scaffolding (meta-test)
 
 ### Plan-Review Skill
 - [ ] Task 8: Audit plan-review command and classify behavioral instructions
@@ -83,11 +83,11 @@ Convert the **Planner** role group of dev-infra commands to skills. This stage c
 ## ✅ Definition of Done
 
 - [x] decision skill exists with interview workflow and ADR behavioral contract
-- [ ] write-plan decomposition decided and implemented (single or family)
+- [x] write-plan decomposition decided and implemented (single or family)
 - [ ] plan-review skill exists with staged-planning path support
 - [ ] All skills pass five-property rubric with populated gotchas
 - [ ] Self-containment (FR-8) verified for each skill
-- [ ] All Stage 3 skills have `assets/` (where applicable) + `references/structure.yaml`
+- [ ] All Stage 3 skills have `assets/` (where applicable) + `references/structure.yaml` *(write-plan done; decision/plan-review pending)*
 - [ ] 3 commands archived: decision.md, transition-plan.md, plan-review.md
 - [ ] CI passes after cutover
 - [ ] Stage 3 exit criteria from design.md Section 5 verified

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/status-and-next-steps.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/status-and-next-steps.md
@@ -7,12 +7,12 @@
 
 ## 📊 Progress Summary
 
-**Overall:** 3/12 tasks complete
+**Overall:** 7/12 tasks complete
 
 | Group | Status | Progress | Notes |
 |-------|--------|----------|-------|
-| Decision Skill | ✅ Active/Complete | 3/3 tasks | Merged PR #92 — audit, `decision/SKILL.md`, validation GO |
-| Write-Plan Skill | 🔴 Not Started | 0/4 tasks | Audit, decomposition decision, convert, validate |
+| Decision Skill | ✅ Active/Complete | 3/3 tasks | Merged PR #92; audit, `decision/SKILL.md`, validation GO |
+| Write-Plan Skill | ✅ Active/Complete | 4/4 tasks | Audit, single-skill decision, `write-plan/` + assets + structure.yaml, meta-test GO |
 | Plan-Review Skill | 🔴 Not Started | 0/2 tasks | Audit, convert (staged-planning path support) |
 | Cutover and Quality Gate | 🔴 Not Started | 0/3 tasks | Install, rubric sweep, exit criteria |
 
@@ -20,17 +20,17 @@
 
 ## 🚀 Next Steps
 
-1. **Group 2** — write-plan skill: audit `transition-plan`, decomposition, convert, validate against Stage 3 scaffolding
+1. **Group 3** — plan-review skill: audit `plan-review`, convert with `assets/` + `references/`, staged `planning-stageN/` paths
 
 ---
 
 ## 📝 Notes
 
 - Stage 3 entry criteria met: Stage 2 go decision logged 2026-05-02
-- Open question: write-plan decomposition (single vs family) — resolved during Group 2 audit
+- **Write-plan decomposition:** single skill with Setup + Expand (see `artifacts/transition-plan-command-audit.md` + `tasks/02-write-plan-skill.md`)
 - Source commands: decision (632 lines), transition-plan (820 lines), plan-review (416 lines)
 - plan-review key improvement: add `planning-stageN/` path support and prior-learnings carry-forward
-- Stage 1-2 patterns apply: five-property rubric, templates-as-assets, family pattern (if decomposed), clean cutover
+- Stage 1-2 patterns apply: five-property rubric, templates-as-assets, clean cutover
 
 ---
 

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/status-and-next-steps.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/status-and-next-steps.md
@@ -11,7 +11,7 @@
 
 | Group | Status | Progress | Notes |
 |-------|--------|----------|-------|
-| Decision Skill | ✅ Active/Complete | 3/3 tasks | Audit artifact, `decision/SKILL.md`, validation GO |
+| Decision Skill | ✅ Active/Complete | 3/3 tasks | Merged PR #92 — audit, `decision/SKILL.md`, validation GO |
 | Write-Plan Skill | 🔴 Not Started | 0/4 tasks | Audit, decomposition decision, convert, validate |
 | Plan-Review Skill | 🔴 Not Started | 0/2 tasks | Audit, convert (staged-planning path support) |
 | Cutover and Quality Gate | 🔴 Not Started | 0/3 tasks | Install, rubric sweep, exit criteria |
@@ -31,6 +31,12 @@
 - Source commands: decision (632 lines), transition-plan (820 lines), plan-review (416 lines)
 - plan-review key improvement: add `planning-stageN/` path support and prior-learnings carry-forward
 - Stage 1-2 patterns apply: five-property rubric, templates-as-assets, family pattern (if decomposed), clean cutover
+
+---
+
+## Completed milestones
+
+- **Group 1 — Decision skill** — merged via [PR #92](https://github.com/grimm00/dev-infra/pull/92) (2026-05-03)
 
 ---
 

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/tasks/01-decision-skill.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/tasks/01-decision-skill.md
@@ -2,7 +2,7 @@
 
 **Feature:** Agentic Workflow Modernization (Stage 3: Planner)
 **Group:** Decision Skill
-**Status:** ✅ Expanded
+**Status:** ✅ Complete
 **Last Updated:** 2026-05-02
 
 ---

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/tasks/02-write-plan-skill.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/tasks/02-write-plan-skill.md
@@ -2,49 +2,50 @@
 
 **Feature:** Agentic Workflow Modernization (Stage 3: Planner)
 **Group:** Write-Plan Skill
-**Status:** 🔴 Scaffolding (needs expansion)
+**Status:** ✅ Expanded
 **Last Updated:** 2026-05-02
 
 ---
 
 ## 📝 Tasks
 
-> ⚠️ **Scaffolding:** Run `/write-plan agentic-workflow-modernization --expand --group 2` to add detailed implementation notes.
+- [x] Task 4: Audit transition-plan command modes and classify behavioral instructions
+  - **Purpose:** Evidence for decomposition and template extraction before SKILL work.
+  - **Steps:**
+    1. Read `.cursor/commands/transition-plan.md` end-to-end; map Setup vs Expand vs shared regions.
+    2. Classify major sections per ADR-004 tiers; flag template fences for `assets/`.
+    3. Estimate behavioral overlap between modes (sequential pipeline vs independent workflows).
+    4. Write `planning-stage3/artifacts/transition-plan-command-audit.md`.
+  - **Files:** `planning-stage3/artifacts/transition-plan-command-audit.md`
+  - **Acceptance:** Artifact has mode matrix, tier table, template inventory, five-property notes.
 
-- [ ] Task 4: Audit transition-plan command modes and classify behavioral instructions
-  - Read `.cursor/commands/transition-plan.md` (820 lines — largest Stage 3 command)
-  - Map setup mode vs expand mode: identify shared logic, mode-specific logic, mode boundaries
-  - Classify instructions against precision tiers; note which are mode-specific
-  - **Identify template-extractable content:** directory scaffolding structures, file templates (implementation-plan.md, status-and-next-steps.md, task file skeletons) — these become `assets/`
-  - Produce audit artifact at `planning-stage3/artifacts/transition-plan-command-audit.md`
+- [x] Task 5: Resolve decomposition — single skill vs family
+  - **Purpose:** Close design.md Section 6 open question with data.
+  - **Steps:**
+    1. Apply audit heuristic: shared **contract** (paths, YAML, output shape) vs mode-specific steps.
+    2. Compare to research family rationale (independent lifecycles vs sequential phases).
+    3. Record decision + rationale below (**Decomposition decision**).
+  - **Files:** This section + audit recommendation (cross-check).
+  - **Acceptance:** Single vs family stated; references audit; aligns with Task 6 layout.
 
-- [ ] Task 5: Resolve decomposition — single skill vs family
-  - design.md Section 6 open question: "may decompose into write-plan-setup and write-plan-expand, or stay single if modes are thin enough"
-  - Use audit data: if modes share <30% behavioral instructions, family pattern (like research); if >70% shared, single skill with mode sections
-  - Document decision with rationale in task file
+- [x] Task 6: Convert transition-plan command to write-plan SKILL.md(s) per decomposition decision
+  - **Purpose:** Ship portable skill with `assets/` + `references/structure.yaml`.
+  - **Steps:**
+    1. Add `templates/standard-project/.claude/skills/write-plan/SKILL.md` (Setup + Expand, input modes including `from_design`).
+    2. Add `assets/implementation-plan.md`, `assets/status-and-next-steps.md`, `assets/task-group-skeleton.md` from command templates.
+    3. Add `references/structure.yaml` (inputs, planning roots including `planning-stageN/`, outputs).
+    4. Apply five-property rubric; populate gotchas (≥6).
+  - **Files:** `templates/standard-project/.claude/skills/write-plan/**`
+  - **Acceptance:** Directory matches convention; no 800-line template paste inside SKILL.
 
-- [ ] Task 6: Convert transition-plan command to write-plan SKILL.md(s) per decomposition decision
-  - **Skill directory structure (new convention):**
-    ```
-    skills/write-plan/
-    ├── SKILL.md                          # behavioral contract + workflow
-    ├── assets/
-    │   ├── implementation-plan.md        # copyable template
-    │   ├── status-and-next-steps.md      # copyable template
-    │   └── task-group-skeleton.md        # copyable template for task files
-    └── references/
-        └── structure.yaml               # declares expected output structure
-    ```
-  - If family: parent SKILL.md + `write-plan-setup/SKILL.md` + `write-plan-expand/SKILL.md` (assets live in parent, shared by children)
-  - `references/structure.yaml` must declare: output directories, singleton files, collection files (task groups), and input modes (`--from-artifacts`, `--from-design`, etc.)
-  - Apply five-property rubric; populate gotchas
-  - Consider `--from-design` as a natural input mode addition (this stage used design.md as input)
-
-- [ ] Task 7: Validate write-plan skill against Stage 3's own scaffolding
-  - Meta-test: this stage's planning was created using the command; validate the skill can produce equivalent output
-  - Verify `assets/` templates match what the command would generate
-  - Verify `references/structure.yaml` accurately describes the output shape
-  - Document verdict in task file's Validation Log
+- [x] Task 7: Validate write-plan skill against Stage 3's own scaffolding
+  - **Purpose:** Meta-test that the skill could reproduce this stage’s planning tree shape.
+  - **Steps:**
+    1. Compare `assets/*` to `planning-stage3/implementation-plan.md`, `status-and-next-steps.md`, and group file headers.
+    2. Cross-check `references/structure.yaml` to actual dirs (`tasks/`, singletons, `planning-stage3` note).
+    3. Record **Validation Log** verdict.
+  - **Files:** This task file (Validation Log)
+  - **Acceptance:** GO/NO-GO with concrete file references.
 
 ---
 
@@ -59,20 +60,52 @@
 
 ## ✅ Completion Criteria
 
-- [ ] Audit artifact with mode mapping, tier classification, and template inventory
-- [ ] Decomposition decision documented with rationale
-- [ ] SKILL.md(s) in templates with rubric pass and gotchas
-- [ ] `assets/` directory with copyable templates
-- [ ] `references/structure.yaml` with output schema
-- [ ] Validation log with meta-test verdict
+- [x] Audit artifact with mode mapping, tier classification, and template inventory
+- [x] Decomposition decision documented with rationale
+- [x] SKILL.md in templates with rubric pass and gotchas
+- [x] `assets/` directory with copyable templates
+- [x] `references/structure.yaml` with output schema
+- [x] Validation log with meta-test verdict
+
+---
+
+## Decomposition decision (Task 5)
+
+**Verdict:** **Single skill:** `write-plan` with two workflows (**Setup** and **Expand**) in one `SKILL.md`.
+
+**Evidence (from audit):**
+- Setup-only and Expand-only *steps* split roughly 40% / 22% of instruction units, with ~38% shared tables and contracts — raw counts alone suggest a family, but the **shared rubric surface** (path roots, frontmatter validity, file naming, error classes) is what agents must not get wrong in either phase.
+- Expand **depends** on Setup artifacts; the modes are **sequential phases** of one capability, unlike **research** (research-setup / research-conduct / research-consolidate as separable invocations).
+
+**design.md §6:** “May decompose into write-plan-setup and write-plan-expand, or stay single if modes are thin enough” — modes are **thick in prose** but **thin as separate products**; a family would duplicate structure.yaml and path rules or force a parent read for every child, yielding little clarity gain.
+
+**If we chose family anyway:** Parent + two children with `read ../SKILL.md` pattern — **deferred** unless product feedback demands separate invocations.
+
+---
+
+## 📋 Validation Log (Task 7)
+
+**Date:** 2026-05-02  
+**Reference tree:** `planning-stage3/`
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| `implementation-plan.md` shape vs `assets/implementation-plan.md` | Pass | Same frontmatter keys, overview + goals + checkbox sections + Definition of Done; Stage 3 file has extra “Related” block — skill template includes Related placeholder. |
+| `status-and-next-steps.md` vs asset | Pass | Progress table + Next Steps + Notes pattern matches; Stage 3 uses emoji status columns consistent with template. |
+| Group file scaffold vs `task-group-skeleton.md` | Pass | `tasks/03-plan-review-skill.md` still on scaffolding banner (not yet expanded) — matches pre-expand skeleton intent; expanded groups match post-expand expectation. |
+| `references/structure.yaml` | Pass | Declares `tasks/`, singletons, `planning-stageN/` note, input_modes including `from_design`. |
+| SKILL self-containment (FR-8) | Pass | Core workflows readable without reading `.cursor/commands/transition-plan.md`; command referenced only as “archived” pointer. |
+
+**Verdict:** **GO**
+
+**Rationale:** Assets and YAML describe the Stage 3 tree; minor optional sections (extra Related links) are placeholders in assets and acceptable variance. Live regeneration would need source content (ADRs/design); static structural parity holds.
 
 ---
 
 ## 🔗 Dependencies
 
 - No hard dependency on Group 1 (decision), but shared audit patterns apply
-- Decomposition decision (Task 5) gates Task 6
-- **Group 1 follow-up:** decision skill needs template extraction into `assets/` (can happen during this group or cutover)
+- **Group 1 follow-up:** decision skill template extraction into `assets/` (Group 2 convention establishes pattern; decision work deferred per Group 1 task file)
 
 ---
 

--- a/templates/standard-project/.claude/skills/write-plan/SKILL.md
+++ b/templates/standard-project/.claude/skills/write-plan/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: write-plan
+description: >-
+  Create or expand implementation planning documents (implementation-plan.md,
+  status-and-next-steps.md, tasks/) from ADRs, artifacts, reflection output, or
+  design docs. Setup mode scaffolds the tree; Expand mode deepens one task group.
+  Use when the user wants /transition-plan, planning scaffolding, or to expand a
+  planning group. Read references/structure.yaml for output shape; copy templates
+  from assets/ rather than inventing filenames.
+disable-model-invocation: true
+---
+
+# Write-Plan
+
+Replace the `/transition-plan` command with a **two-phase skill**: **Setup**
+(scaffold planning tree) and **Expand** (add detail to one group file). Both
+phases share path detection, YAML frontmatter rules, and output layout — see
+`references/structure.yaml`.
+
+---
+
+## When to use
+
+- After decisions or design work and the user wants an actionable task plan.
+- User says `/transition-plan`, “scaffold implementation plan”, “expand group N”.
+- Staged work needs `planning/…` or `planning-stageN/…` under a feature.
+
+## When not to use
+
+- No source material (ADR, artifact, reflection, or design) agreed — gather
+  inputs first.
+- Only code changes, no planning tree — use implementation tasks, not this skill.
+
+---
+
+## Path detection
+
+Pick **one** planning root and use it for the whole invocation:
+
+| Layout | Planning root |
+|--------|----------------|
+| Dev-infra feature | `admin/services/[service]/features/[feature]/` + **`planning/`** or **`planning-stage{N}/`** |
+| Template maintainer | `docs/maintainers/planning/features/[feature]/` |
+
+**Staged planning:** If the feature already uses `planning-stage2/`, `planning-stage3/`, etc., create **sibling** directories — do not silently merge into an old stage without user confirmation.
+
+**Detection:** If `admin/services/` applies, prefer feature-local paths. Otherwise use maintainer docs layout. Document the chosen subdirectory in `status-and-next-steps.md` Notes.
+
+---
+
+## Preconditions (stop if unmet)
+
+1. **Topic / feature name** is known or inferable from context.
+2. **Input mode** identified: `from_adr` | `from_artifacts` | `from_reflection` | `from_design`.
+3. Source paths exist and are readable.
+
+---
+
+## Input modes
+
+| Mode | Read |
+|------|------|
+| **from_adr** | ADR files under `decisions/…`; optional `research/…/requirements.md` |
+| **from_artifacts** | Given artifact (checklist, handoff doc, transition brief) |
+| **from_reflection** | Reflection doc; if project expects generated artifacts first, surface that dependency |
+| **from_design** | `design.md` or Section excerpts: goals, stages, open questions → task groups |
+
+Extract: decisions, requirements, success criteria, constraints, and suggested group boundaries.
+
+---
+
+## Setup workflow
+
+**Goal:** Create `implementation-plan.md`, `status-and-next-steps.md`, and
+`tasks/NN-group-slug.md` skeletons.
+
+1. **Load sources** per Input modes above.
+2. **Choose transition type:** feature (default), release (source path or content mentions release/version), or ci-cd if pipeline-only scope.
+3. **Organize task groups:** 2–8 tasks per group; **global** task numbering 1…N across all groups; kebab-case group filenames.
+4. **Author `implementation-plan.md`:**
+   - YAML frontmatter: `task_count`, `groups` (name, file, task ids), `tasks_files`.
+   - Body: checkbox list matching `task_count` exactly. See `assets/implementation-plan.md`.
+5. **Author `status-and-next-steps.md`:** progress table + next steps. See `assets/status-and-next-steps.md`.
+6. **Author each `tasks/NN-….md`:** copy `assets/task-group-skeleton.md`; fill titles and one-line hints only (**no** long TDD blocks yet). Header `**Status:** 🔴 Scaffolding (needs expansion)`.
+7. **Commit guidance:** suggest `docs([feature]): …` or project convention; do not require dev-infra-specific branch polish unless the repo uses it.
+
+---
+
+## Expand workflow
+
+**Goal:** One group file gains detailed steps, acceptance criteria, and files.
+
+**Trigger:** User specifies group index (1-based) or group name; optional `--all` for small plans only.
+
+1. **Locate group file** from frontmatter `groups[].file`.
+2. **Verify status** is scaffolding. If already `✅ Expanded`, skip or re-expand only on explicit request.
+3. **Classify group type** for order of detail:
+   | Type | Order |
+   |------|-------|
+   | Code + tests | RED → GREEN → REFACTOR in task text |
+   | Scripts | tests → script → integration |
+   | Docs / planning only | outline → link → verify |
+4. **Rewrite each task** with Purpose, Steps/TDD, Files, Acceptance.
+5. **Update header:** `**Status:** ✅ Expanded`; remove scaffolding banner.
+6. **Commit** with a scoped message describing the expanded group.
+
+---
+
+## Behavioral contract
+
+- **Observable:** Every task checkbox in `implementation-plan.md` maps to exactly one row in a group file; filenames match `tasks_files`.
+- **Bounded:** If multiple features match, **stop** and ask which `feature/` directory; do not guess across unrelated features.
+- **Outcome-framed:** Deliver files under the chosen planning root; use templates in `assets/`.
+- **Delta-only:** Do not paste full multi-hundred-line templates into chat — **copy from `assets/`** on disk.
+- **Failure-aware:** Missing requirements, missing source, or existing `implementation-plan.md` → surface options (abort, new stage dir, `--force` if project allows).
+
+---
+
+## Gotchas
+
+1. **Frontmatter must match body:** `task_count` equals checkbox count; `groups[].tasks` partition 1…N.
+2. **Expand is not Setup:** never delete `implementation-plan.md` when expanding a group.
+3. **`from_reflection` chaining** may depend on another workflow producing artifacts — call that out instead of inventing content.
+4. **Release transitions** reuse the **same file shapes**; only grouping semantics change.
+5. **`--all` expand** is context-heavy — prefer one group at a time for N > 3 groups.
+6. **Staged dirs:** dev-infra Stage 3 uses `planning-stage3/` not `planning/`; mirror sibling pattern the feature already uses.
+
+---
+
+## Related
+
+- **decision** — upstream ADRs.
+- **plan-review** — validate plan before execution.
+- Source command archived in dev-infra: `.cursor/commands/transition-plan.md`.
+
+---
+
+**Canonical shape:** `references/structure.yaml`  
+**Copyable templates:** `assets/implementation-plan.md`, `assets/status-and-next-steps.md`, `assets/task-group-skeleton.md`

--- a/templates/standard-project/.claude/skills/write-plan/assets/implementation-plan.md
+++ b/templates/standard-project/.claude/skills/write-plan/assets/implementation-plan.md
@@ -1,0 +1,68 @@
+---
+task_count: [N]
+groups:
+  - name: "[Group 1 Name]"
+    file: "tasks/01-group-name.md"
+    tasks: [1, 2, 3]
+  - name: "[Group 2 Name]"
+    file: "tasks/02-group-name.md"
+    tasks: [4, 5, 6, 7]
+tasks_files:
+  - "tasks/01-group-name.md"
+  - "tasks/02-group-name.md"
+---
+# Implementation Plan — [Feature Name]
+
+**Status:** 🔴 Not Started
+**Created:** YYYY-MM-DD
+**Last Updated:** YYYY-MM-DD
+**Source:** [source path or description]
+
+---
+
+## 📋 Overview
+
+[2-4 sentences describing the feature and what it achieves]
+
+**Key Changes:**
+- [Change 1]
+- [Change 2]
+
+---
+
+## 🎯 Goals
+
+1. **[Goal 1]** — [description]
+2. **[Goal 2]** — [description]
+
+---
+
+## 📝 Implementation Plan
+
+### [Group 1 Name]
+- [ ] Task 1: [Task title]
+- [ ] Task 2: [Task title]
+- [ ] Task 3: [Task title]
+
+### [Group 2 Name]
+- [ ] Task 4: [Task title]
+- [ ] Task 5: [Task title]
+
+---
+
+## ✅ Definition of Done
+
+- [ ] All tasks complete
+- [ ] CI/CD passing
+- [ ] Documentation updated
+- [ ] Templates synced
+
+---
+
+## 🔗 Related
+
+- [Links to ADRs, design, prior stages]
+
+---
+
+**Last Updated:** YYYY-MM-DD

--- a/templates/standard-project/.claude/skills/write-plan/assets/status-and-next-steps.md
+++ b/templates/standard-project/.claude/skills/write-plan/assets/status-and-next-steps.md
@@ -1,0 +1,33 @@
+# Status & Next Steps — [Feature Name]
+
+**Status:** 🔴 Not Started
+**Last Updated:** YYYY-MM-DD
+
+---
+
+## 📊 Progress Summary
+
+**Overall:** 0/[N] tasks complete
+
+| Group | Status | Progress | Notes |
+|-------|--------|----------|-------|
+| [Group 1] | 🔴 Not Started | 0/[X] tasks | |
+| [Group 2] | 🔴 Not Started | 0/[Y] tasks | |
+
+---
+
+## 🚀 Next Steps
+
+1. Review scaffolding — verify group/task breakdown.
+2. Expand groups — run write-plan **Expand** for group 1.
+3. Start implementation — project task runner / next task.
+
+---
+
+## 📝 Notes
+
+- Plan generated from [source] on YYYY-MM-DD.
+
+---
+
+**Last Updated:** YYYY-MM-DD

--- a/templates/standard-project/.claude/skills/write-plan/assets/task-group-skeleton.md
+++ b/templates/standard-project/.claude/skills/write-plan/assets/task-group-skeleton.md
@@ -1,0 +1,42 @@
+# [Group Name]
+
+**Feature:** [Feature Name]
+**Group:** [Group Name]
+**Status:** 🔴 Scaffolding (needs expansion)
+**Last Updated:** YYYY-MM-DD
+
+---
+
+## 📝 Tasks
+
+- [ ] Task [X]: [Title]
+  - [1-2 sentence description from source]
+  - [Key deliverable or acceptance criterion]
+
+- [ ] Task [Y]: [Title]
+  - [1-2 sentence description from source]
+  - [Key deliverable or acceptance criterion]
+
+---
+
+## 🎯 Goals
+
+1. [Goal extracted from source]
+2. [Goal extracted from source]
+
+---
+
+## ✅ Completion Criteria
+
+- [ ] [Criterion 1]
+- [ ] [Criterion 2]
+
+---
+
+## 🔗 Dependencies
+
+- [Dependency on prior group or task, if any]
+
+---
+
+**Last Updated:** YYYY-MM-DD

--- a/templates/standard-project/.claude/skills/write-plan/references/structure.yaml
+++ b/templates/standard-project/.claude/skills/write-plan/references/structure.yaml
@@ -1,0 +1,63 @@
+# Declarative contract for write-plan skill outputs and inputs.
+# Human and agent readers: use this alongside SKILL.md for path and shape truth.
+
+schema_version: 1
+skill: write-plan
+
+# Logical input channels (mirror command flags; design.md may be used like artifacts).
+input_modes:
+  - id: from_adr
+    description: ADR directory or files under decisions/
+    typical_flags: ["--from-adr"]
+  - id: from_artifacts
+    description: Single artifact file (e.g. checklist, transition brief)
+    typical_flags: ["--from-artifacts"]
+  - id: from_reflection
+    description: Reflection doc; may imply artifact generation first
+    typical_flags: ["--from-reflection"]
+  - id: from_design
+    description: Feature design document (sections with goals, scope, staging)
+    typical_flags: ["--from-design"]
+    notes: Natural extension for Stage 3-style planning sourced from design.md
+
+# Where the planning tree is rooted on disk (one of these conventions per repo).
+planning_roots:
+  dev_infra_feature:
+    description: Feature work under admin/services
+    base_glob: "admin/services/{service}/features/{feature}/"
+    default_subdir: planning
+    staged_planning_subdir_pattern: "planning-stage{N}/"
+    notes: Stage 3 of this feature uses planning-stage3/ instead of planning/
+  template_project:
+    description: Maintainer docs layout in generated projects
+    base_glob: "docs/maintainers/planning/features/{feature}/"
+
+# Files the skill creates or updates (Setup and Expand).
+outputs:
+  directories:
+    - path: tasks
+      role: One markdown file per task group
+      naming: "{nn}-{group-slug}.md"
+  singletons:
+    - filename: implementation-plan.md
+      role: YAML frontmatter + task index with GFM checkboxes
+      created_in: setup
+    - filename: status-and-next-steps.md
+      role: Progress table and next steps
+      created_in: setup
+  collections:
+    - pattern: "tasks/*.md"
+      role: Group files; Setup creates scaffolding; Expand deepens one group
+      setup_status: "🔴 Scaffolding (needs expansion)"
+      expanded_status: "✅ Expanded"
+
+# Frontmatter contract (must match implementation-plan body checkboxes).
+implementation_plan_frontmatter:
+  required_keys:
+    - task_count
+    - groups
+    - tasks_files
+  group_entry_shape:
+    name: string
+    file: string
+    tasks: list_of_integers

--- a/templates/standard-project/.claude/skills/write-plan/references/structure.yaml
+++ b/templates/standard-project/.claude/skills/write-plan/references/structure.yaml
@@ -26,6 +26,8 @@ planning_roots:
     description: Feature work under admin/services
     base_glob: "admin/services/{service}/features/{feature}/"
     default_subdir: planning
+    # N is a 1-based positive integer (1, 2, 3, …). Directory name is literal prefix
+    # "planning-stage" + decimal digits (no zero-padding required): planning-stage3, planning-stage12, etc.
     staged_planning_subdir_pattern: "planning-stage{N}/"
     notes: Stage 3 of this feature uses planning-stage3/ instead of planning/
   template_project:
@@ -57,6 +59,9 @@ implementation_plan_frontmatter:
     - task_count
     - groups
     - tasks_files
+  # Consistency: tasks_files must be the ordered list of `groups[].file` values in the same
+  # order as `groups` (each path appears exactly once). groups[].tasks lists global task IDs
+  # 1..task_count covered by that group’s checkboxes in the body.
   group_entry_shape:
     name: string
     file: string


### PR DESCRIPTION
## Summary

- Add Stage 3 **transition-plan → write-plan** conversion: new skill under `templates/standard-project/.claude/skills/write-plan/` with **Setup** and **Expand** workflows (single skill; no setup/expand child split).
- Introduce **`assets/`** copyable templates (`implementation-plan`, `status-and-next-steps`, `task-group-skeleton`) and **`references/structure.yaml`** describing planning outputs, input modes (including `from_design`), and `planning-stageN/` roots.
- Add **`planning-stage3/artifacts/transition-plan-command-audit.md`**: mode mapping, ADR-004 tier notes, template inventory, decomposition rationale.
- Expand **`tasks/02-write-plan-skill.md`** with completed Tasks 4–7, decomposition decision, and validation log (**GO**).
- Refresh **`implementation-plan.md`** / **`status-and-next-steps.md`**: 7/12 tasks, Group 2 complete, next = plan-review; document PR #92 milestone and Group 1 group-file status (**Complete**).

## Why

Stage 3 Planner modernization needs the largest command (`transition-plan`, 820 lines) encoded as a portable skill without losing structure. Group 2 closes **design.md** open question on mode decomposition (single skill vs family) with audit evidence and establishes the **assets + references** convention for later Stage 3 skills and the deferred decision-skill template extraction.

## After Merge

- **Generated projects** that sync or copy `templates/standard-project/.claude/skills/` gain **`write-plan`** alongside existing skills; cutover/archiving of `.cursor/commands/transition-plan.md` is reserved for **Cutover and quality gate** (Stage 3 tasks 10–12), not this PR.
- **No CI workflow file or runtime behavior changes** in app code — template and planning-doc updates only. Template consumers should skim new skill + YAML when maintaining planning automation.
- **Planning-stage3** truth moves to **7/12** tasks; Group 3 (plan-review) is the documented next step.

## Follow-ups

- **Group 3:** plan-review skill + audit; staged `planning-stageN/` path behavior.
- **Group 1 follow-up (from task file):** extract **decision** inline templates into `assets/` + `references/structure.yaml` (convention now established by write-plan).
- **Cutover task:** archive `transition-plan` command and wire install paths when Cutover group runs.
