### PR TITLE
feat(agentic-workflow-modernization): Skill Family Restructure (Group 3)

### DIFF
--- a/admin/feedback/sourcery/pr94.md
+++ b/admin/feedback/sourcery/pr94.md
@@ -1,0 +1,162 @@
+# Sourcery Review Analysis
+**PR**: #94
+**Repository**: grimm00/dev-infra
+**Generated**: Sat May  2 22:01:29 CDT 2026
+
+---
+
+## Summary
+
+Total Individual Comments: 3 + Overall Comments
+
+## Individual Comments
+
+### Comment #1
+
+**Type**: issue
+
+**Description**: This mentions `implementation-plan.yaml`, but the only declared singleton is `implementation-plan.md` with YAML frontmatter. If the intent is to protect the frontmatter block in the `.md` file, please rephrase accordingly (e.g., “YAML frontmatter block in implementation-plan.md”) to avoid confusion for readers and tooling.
+
+<details>
+<summary>Details</summary>
+
+<b>Code Context</b>
+
+<pre><code>
++    - pattern: &quot;tasks/{target-group-md}&quot;
++      role: Exactly one group&#x27;s markdown deepened per run (Purpose/Steps/Acceptance)
++      promoted_status_when_complete: &quot;✅ Expanded&quot;
++  singletons_touch_policy: &gt;
++    Rare advisory edits only (never delete implementation-plan.yaml block); root files
++    should already exist before expand executes.
++
+</code></pre>
+
+<b>Issue</b>
+
+**issue:** Frontmatter note references `implementation-plan.yaml` while the file is declared as a `.md` file.
+
+</details>
+
+---
+
+### Comment #2
+
+**Type**: Load sources
+
+**Description**: Here, “ci-cd if pipeline-only” should be “CI/CD” to align with standard capitalization and avoid reading like a typo.
+
+<details>
+<summary>Details</summary>
+
+<b>Code Context</b>
+
+<pre><code>
++scaffolding-only `tasks/NN-group-slug.md` files under the resolved planning root.
++
++1. **Load sources** using the declared input mode — extract grouping signals the way a human planner would summarize them (decisions, requirements, constraints, phased scope).
++2. **Choose transition type:** feature (default), release when path/content signals
++   a release rollout, ci-cd if pipeline-only.
++3. **Organize groups:** target 2–8 tasks per group; **global** numbering 1…N;
++   filenames `tasks/{NN}-{kebab-case}.md`.
+</code></pre>
+
+<b>Issue</b>
+
+**suggestion (typo):** Use the more standard capitalization “CI/CD” instead of “ci-cd”.
+
+<b>Suggestion</b>
+
+<pre><code>
+2. **Choose transition type:** feature (default), release when path/content signals
+   a release rollout, CI/CD if pipeline-only.
+</code></pre>
+
+</details>
+
+---
+
+### Comment #3
+
+**Type**: Rewrite each `- [ ] Task …` block
+
+**Description**: If you do mean the Bash Automated Testing System here, please spell it out or add a brief note so readers recognize it. Otherwise, consider replacing “bats” with “tests” for clarity in this ordering.
+
+<details>
+<summary>Details</summary>
+
+<b>Code Context</b>
+
+<pre><code>
++   | Type | Order inside each task row |
++   |------|----------------------------|
++   | Code + automated tests | RED → GREEN → REFACTOR phrasing inside Steps |
++   | Scripts / tooling | bats → script → integration |
++   | Docs / coordination | outline → link → verify reads |
++5. **Rewrite each `- [ ] Task …` block** adding **Purpose**, **Steps or TDD Flow**,
+</code></pre>
+
+<b>Issue</b>
+
+**question (typo):** Clarify whether “bats” is intentional (the Bash test framework) or a typo for “tests”.
+
+<b>Suggestion</b>
+
+<pre><code>
+   | Scripts / tooling | Bats (Bash Automated Testing System) → script → integration |
+</code></pre>
+
+</details>
+
+---
+
+## Overall Comments
+
+- In `write-plan-setup/SKILL.md` you describe `groups[]` with an integer `tasks` field, but `write-plan/references/structure.yaml` defines `groups[].tasks` as a list_of_integers; aligning these descriptions will avoid confusion about the expected frontmatter shape.
+- The `optional_parent_index_updates` entry in `decision/references/structure.yaml` encodes two alternative paths in a single `filename` value (`docs/maintainers/decisions/README.md OR admin/decisions/README.md`), which may be hard for tools to consume; consider representing these as separate entries or adding a structured field to capture the alternatives.
+- In several places you still reference legacy `/transition-plan` invocation text while also introducing `write-plan-setup`/`write-plan-expand` (e.g., expand workflow trigger cues and related sections); it may be clearer to consistently foreground the new skill names and treat `/transition-plan` wording as legacy aliases only where strictly needed.
+
+## Priority Matrix Assessment
+
+Use this template to assess each comment:
+
+| Comment | Priority | Impact | Effort | Action |
+|---------|----------|--------|--------|--------|
+| #1 | MEDIUM | MEDIUM | LOW | Clarified YAML frontmatter lives in **`implementation-plan.md`** (`references/structure.yaml` + expand skill wording). |
+| #2 | LOW | LOW | LOW | Normalized **`CI/CD`** capitalization in **`write-plan-setup`**. |
+| #3 | LOW | MEDIUM | LOW | Documented **Bats (Bash Automated Testing System)** in expand classify matrix. |
+
+### Overall reviewer notes (resolution)
+
+| Note | Action |
+|------|--------|
+| `groups[].tasks` SKILL vs YAML | Updated **`write-plan-setup`** to describe **`tasks` as YAML list of integers** matching structure.yaml. |
+| `optional_parent_index_updates` dual path | Split into **two YAML entries** in **`decision/references/structure.yaml`**. |
+| Legacy `/transition-plan` vs new names | Prefer **`write-plan-setup` / `write-plan-expand`** in triggers and YAML descriptions; **`/transition-plan`** retained as legacy alias only. |
+
+---
+
+## Resolution (branch updates)
+
+- **#1:** `references/structure.yaml` `singletons_touch_policy`; expand workflow trigger text reviewed.
+- **#2:** `write-plan-setup` transition-type step uses **CI/CD**.
+- **#3:** Expand matrix row spells out **Bats**; overall legacy naming cleanup as above.
+
+### Priority Levels
+- 🟠 **HIGH**: Bug risks or significant maintainability issues
+- 🟡 **MEDIUM**: Code quality and maintainability improvements
+- 🟢 **LOW**: Nice-to-have improvements
+
+### Impact Levels
+- 🔴 **CRITICAL**: Affects core functionality
+- 🟠 **HIGH**: User-facing or significant changes
+- 🟡 **MEDIUM**: Developer experience improvements
+- 🟢 **LOW**: Minor improvements
+
+### Effort Levels
+- 🟢 **LOW**: Simple, quick changes
+- 🟡 **MEDIUM**: Moderate complexity
+- 🟠 **HIGH**: Complex refactoring
+- 🔴 **VERY_HIGH**: Major rewrites
+
+

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/implementation-plan.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/implementation-plan.md
@@ -29,7 +29,8 @@ tasks_files:
 **Created:** 2026-05-02
 **Last Updated:** 2026-05-02
 **Source:** [ADRs 1-5 + design.md Section 5](../decisions/) → Stage 3 of 4-stage v1  
-**Group 1 merged:** PR #92 (2026-05-03)
+**Group 1 merged:** PR #92 (2026-05-03)  
+**Group 2 merged:** PR #93 (2026-05-03)
 
 ---
 

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/implementation-plan.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/implementation-plan.md
@@ -77,7 +77,7 @@ Convert the **Planner** role group of dev-infra commands to skills. This stage c
 
 ### Skill Family Restructure
 - [x] Task 8: Restructure write-plan into family (parent + write-plan-setup + write-plan-expand)
-- [ ] Task 9: Restructure decision skill with assets/ + references/
+- [x] Task 9: Restructure decision skill with assets/ + references/
 - [ ] Task 10: Validate restructured skills (rubric + structure.yaml accuracy)
 
 ### Plan-Review Skill
@@ -95,7 +95,7 @@ Convert the **Planner** role group of dev-infra commands to skills. This stage c
 
 - [x] decision skill exists with interview workflow and ADR behavioral contract
 - [x] write-plan is a family: parent + write-plan-setup + write-plan-expand
-- [ ] decision has `assets/` + `references/structure.yaml`
+- [x] decision has `assets/` + `references/structure.yaml`
 - [ ] plan-review skill exists with staged-planning path support
 - [ ] All skills pass five-property rubric with populated gotchas
 - [ ] Self-containment (FR-8) verified for each skill

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/implementation-plan.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/implementation-plan.md
@@ -78,7 +78,7 @@ Convert the **Planner** role group of dev-infra commands to skills. This stage c
 ### Skill Family Restructure
 - [x] Task 8: Restructure write-plan into family (parent + write-plan-setup + write-plan-expand)
 - [x] Task 9: Restructure decision skill with assets/ + references/
-- [ ] Task 10: Validate restructured skills (rubric + structure.yaml accuracy)
+- [x] Task 10: Validate restructured skills (rubric + structure.yaml accuracy)
 
 ### Plan-Review Skill
 - [ ] Task 11: Audit plan-review command and classify behavioral instructions

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/implementation-plan.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/implementation-plan.md
@@ -76,7 +76,7 @@ Convert the **Planner** role group of dev-infra commands to skills. This stage c
 - [x] Task 7: Validate write-plan skill against Stage 3's own scaffolding (meta-test)
 
 ### Skill Family Restructure
-- [ ] Task 8: Restructure write-plan into family (parent + write-plan-setup + write-plan-expand)
+- [x] Task 8: Restructure write-plan into family (parent + write-plan-setup + write-plan-expand)
 - [ ] Task 9: Restructure decision skill with assets/ + references/
 - [ ] Task 10: Validate restructured skills (rubric + structure.yaml accuracy)
 
@@ -94,7 +94,7 @@ Convert the **Planner** role group of dev-infra commands to skills. This stage c
 ## ✅ Definition of Done
 
 - [x] decision skill exists with interview workflow and ADR behavioral contract
-- [ ] write-plan is a family: parent + write-plan-setup + write-plan-expand
+- [x] write-plan is a family: parent + write-plan-setup + write-plan-expand
 - [ ] decision has `assets/` + `references/structure.yaml`
 - [ ] plan-review skill exists with staged-planning path support
 - [ ] All skills pass five-property rubric with populated gotchas

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/status-and-next-steps.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/status-and-next-steps.md
@@ -12,7 +12,7 @@
 | Group | Status | Progress | Notes |
 |-------|--------|----------|-------|
 | Decision Skill | ✅ Active/Complete | 3/3 tasks | Merged PR #92; audit, `decision/SKILL.md`, validation GO |
-| Write-Plan Skill | ✅ Active/Complete | 4/4 tasks | Audit, single-skill decision, `write-plan/` + assets + structure.yaml, meta-test GO |
+| Write-Plan Skill | ✅ Active/Complete | 4/4 tasks | Merged [PR #93](https://github.com/grimm00/dev-infra/pull/93): audit, single-skill `write-plan/` + assets + structure.yaml, meta-test GO |
 | Skill Family Restructure | 🔴 Not Started | 0/3 tasks | Split write-plan into family, add assets/refs to decision |
 | Plan-Review Skill | 🔴 Not Started | 0/2 tasks | Audit, convert (staged-planning path support) |
 | Cutover and Quality Gate | 🔴 Not Started | 0/3 tasks | Install, rubric sweep, exit criteria |
@@ -39,7 +39,4 @@
 ## Completed milestones
 
 - **Group 1 — Decision skill** — merged via [PR #92](https://github.com/grimm00/dev-infra/pull/92) (2026-05-03)
-
----
-
-**Last Updated:** 2026-05-02
+- **Group 2 — Write-Plan skill** — merged via [PR #93](https://github.com/grimm00/dev-infra/pull/93) (2026-05-03)

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/status-and-next-steps.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/status-and-next-steps.md
@@ -7,13 +7,13 @@
 
 ## 📊 Progress Summary
 
-**Overall:** 7/15 tasks complete
+**Overall:** 10/15 tasks complete
 
 | Group | Status | Progress | Notes |
 |-------|--------|----------|-------|
 | Decision Skill | ✅ Active/Complete | 3/3 tasks | Merged PR #92; audit, `decision/SKILL.md`, validation GO |
 | Write-Plan Skill | ✅ Active/Complete | 4/4 tasks | Merged [PR #93](https://github.com/grimm00/dev-infra/pull/93): audit, single-skill `write-plan/` + assets + structure.yaml, meta-test GO |
-| Skill Family Restructure | 🔴 Not Started | 0/3 tasks | Split write-plan into family, add assets/refs to decision |
+| Skill Family Restructure | ✅ Active/Complete | 3/3 tasks | Parent + setup/expand; decision `assets/` + `references/`; validated in-task |
 | Plan-Review Skill | 🔴 Not Started | 0/2 tasks | Audit, convert (staged-planning path support) |
 | Cutover and Quality Gate | 🔴 Not Started | 0/3 tasks | Install, rubric sweep, exit criteria |
 
@@ -21,7 +21,7 @@
 
 ## 🚀 Next Steps
 
-1. **Group 3** — skill family restructure: split write-plan into family (parent + setup + expand), add assets/ + references/ to decision
+1. **Group 4** — Plan-Review skill audit and SKILL conversion (staged planning paths).
 
 ---
 
@@ -40,3 +40,4 @@
 
 - **Group 1 — Decision skill** — merged via [PR #92](https://github.com/grimm00/dev-infra/pull/92) (2026-05-03)
 - **Group 2 — Write-Plan skill** — merged via [PR #93](https://github.com/grimm00/dev-infra/pull/93) (2026-05-03)
+- **Group 3 — Skill family restructure** — delivered on branch `feat/agentic-workflow-stage3-g3` (PR link TBD upon open)

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/status-and-next-steps.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/status-and-next-steps.md
@@ -40,4 +40,4 @@
 
 - **Group 1 — Decision skill** — merged via [PR #92](https://github.com/grimm00/dev-infra/pull/92) (2026-05-03)
 - **Group 2 — Write-Plan skill** — merged via [PR #93](https://github.com/grimm00/dev-infra/pull/93) (2026-05-03)
-- **Group 3 — Skill family restructure** — delivered on branch `feat/agentic-workflow-stage3-g3` (PR link TBD upon open)
+- **Group 3 — Skill family restructure** — [PR #94](https://github.com/grimm00/dev-infra/pull/94)

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/tasks/02-write-plan-skill.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/tasks/02-write-plan-skill.md
@@ -3,6 +3,7 @@
 **Feature:** Agentic Workflow Modernization (Stage 3: Planner)
 **Group:** Write-Plan Skill
 **Status:** ✅ Expanded
+**Merged:** PR #93 (2026-05-03)
 **Last Updated:** 2026-05-02
 
 ---

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/tasks/03-skill-family-restructure.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/tasks/03-skill-family-restructure.md
@@ -18,7 +18,7 @@ explore/research family pattern regardless of interim single-skill decision text
 
 ---
 
-- [ ] Task 8: Restructure write-plan into family (parent + setup + expand)
+- [x] Task 8: Restructure write-plan into family (parent + setup + expand)
   - **Purpose:** Reduce per-invocation context by mirroring `explore/` + `research/` thin-parent ergonomics without losing shared YAML + asset contracts.
   - **Steps:**
     1. Relocate substantive Setup prose into `templates/standard-project/.claude/skills/write-plan/write-plan-setup/SKILL.md` with **`read ../SKILL.md`** gate (family conventions identical pattern to research children).
@@ -68,8 +68,8 @@ explore/research family pattern regardless of interim single-skill decision text
 
 ## ✅ Completion Criteria
 
-- [ ] write-plan is a family: parent + write-plan-setup + write-plan-expand
-- [ ] write-plan parent is a thin orientation hub (like explore, research parents)
+- [x] write-plan is a family: parent + write-plan-setup + write-plan-expand
+- [x] write-plan parent is a thin orientation hub (like explore, research parents)
 - [ ] decision has `assets/` with extracted templates + `references/structure.yaml`
 - [ ] All modified SKILL.md files pass five-property rubric
 - [ ] `references/structure.yaml` files are accurate for both skills

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/tasks/03-skill-family-restructure.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/tasks/03-skill-family-restructure.md
@@ -45,7 +45,7 @@ explore/research family pattern regardless of interim single-skill decision text
 
 ---
 
-- [ ] Task 10: Validate restructured skills
+- [x] Task 10: Validate restructured skills
   - **Purpose:** Guard cutover regressions ahead of Plan-Review (Group 4) + eventual command archival.
   - **Steps:**
     1. **Routing sanity:** Confirm parent forbids mistaken direct invocation wording consistent with explore/research parents (`disable-model-invocation`, explicit child routing).
@@ -71,8 +71,8 @@ explore/research family pattern regardless of interim single-skill decision text
 - [x] write-plan is a family: parent + write-plan-setup + write-plan-expand
 - [x] write-plan parent is a thin orientation hub (like explore, research parents)
 - [x] decision has `assets/` with extracted templates + `references/structure.yaml`
-- [ ] All modified SKILL.md files pass five-property rubric
-- [ ] `references/structure.yaml` files are accurate for both skills
+- [x] All modified SKILL.md files pass five-property rubric
+- [x] `references/structure.yaml` files are accurate for both skills
 
 ---
 
@@ -86,15 +86,17 @@ explore/research family pattern regardless of interim single-skill decision text
 
 ## 📋 Validation notes (Task 10)
 
-_Add GO/NO-GO narrative after onsite verification._
+Executed 2026-05-02 in-repo review (templates/standard-project write-plan family + decision).
 
 | Artifact | Spot-check | Verdict |
 |----------|-------------|---------|
-| `write-plan/SKILL.md` | Parent routing + duplication vs explore parent | Pending |
-| `write-plan-setup`, `write-plan-expand` | `read ../SKILL.md`; contracts + gotchas breadth | Pending |
-| `write-plan/references/structure.yaml` | `setup_output` vs `expand_output` coherence | Pending |
-| `decision/SKILL.md` | Asset pointers replace inline scaffolds | Pending |
-| `decision/references/structure.yaml` | Mirrors interview→hub→ADR→summary flow | Pending |
-| `explore` / `research` parents | Mention **write-plan-setup** not `/transition-plan` | Pending |
+| `write-plan/SKILL.md` | Parent-only orientation; explicit child routing; path table aligns with YAML | ✅ GO |
+| `write-plan-setup`, `write-plan-expand` | Each gates on `read ../SKILL.md`; setup vs expand I/O spelled; STOP/failure cues present | ✅ GO |
+| `write-plan/references/structure.yaml` | `setup_output` vs `expand_output` match filesystem behavior | ✅ GO |
+| `decision/SKILL.md` | Scaffolds live in assets; workflow + behavioral sections retained | ✅ GO |
+| `decision/references/structure.yaml` | Interview singleton → hub → ADR collection → summary | ✅ GO |
+| `explore` / `research` parents | References **write-plan-setup** successor label | ✅ GO |
 
-**Rubric rollup:** Pending explicit tick-box commentary after reviewer pass.
+**Rubric rollup (FR-19) on touched SKILL bodies:** Observability anchored on explicit deliverables/table rows (**Behavioral contract** headings). Bounded scope via Preconditions + explicit cease conditions. Outcome-framed section titles (**Goal:** / workflow objectives). Delta-only reliance on **`assets/`** + YAML instead of pasted templates inline. Failure-aware STOP/escalate language retained on every skill surface post-split.
+
+Overall: **GO** for Group 3 template deliverables pending CI on PR branch.

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/tasks/03-skill-family-restructure.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/tasks/03-skill-family-restructure.md
@@ -32,7 +32,7 @@ explore/research family pattern regardless of interim single-skill decision text
 
 ---
 
-- [ ] Task 9: Restructure decision skill with assets/ + references/
+- [x] Task 9: Restructure decision skill with assets/ + references/
   - **Purpose:** Finish deferred template extraction from Group 1 — align decision with **`assets/` + `references/`** convention already proven on write-plan.
   - **Steps:**
     1. Create **`decision/assets/adr-template.md`**, **`hub-readme-template.md`**, **`decision-interview.md`** mirroring headings previously enumerated inline inside `SKILL.md`.
@@ -70,7 +70,7 @@ explore/research family pattern regardless of interim single-skill decision text
 
 - [x] write-plan is a family: parent + write-plan-setup + write-plan-expand
 - [x] write-plan parent is a thin orientation hub (like explore, research parents)
-- [ ] decision has `assets/` with extracted templates + `references/structure.yaml`
+- [x] decision has `assets/` with extracted templates + `references/structure.yaml`
 - [ ] All modified SKILL.md files pass five-property rubric
 - [ ] `references/structure.yaml` files are accurate for both skills
 

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/tasks/03-skill-family-restructure.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/tasks/03-skill-family-restructure.md
@@ -2,66 +2,67 @@
 
 **Feature:** Agentic Workflow Modernization (Stage 3: Planner)
 **Group:** Skill Family Restructure
-**Status:** 🔴 Scaffolding (needs expansion)
+**Status:** ✅ Expanded
 **Last Updated:** 2026-05-02
 
 ---
 
 ## 📝 Tasks
 
-> ⚠️ **Scaffolding:** Run `/write-plan agentic-workflow-modernization --expand --group 3` to add detailed implementation notes.
+### Pre-phase review pulse (prior group)
+
+`/pre-phase-review` is superseded by `/plan-review`; for this iteration the operator
+validated **Group 2** via merged PR **#93** narrative + Stage 3 doc notes (**Write-plan decomposition
+override** documented in status file). Carry-forward implication: decomposition **now** adopts the explicit
+explore/research family pattern regardless of interim single-skill decision text in Task 5 historical log.
+
+---
 
 - [ ] Task 8: Restructure write-plan into family (parent + setup + expand)
-  - Split the single `write-plan/SKILL.md` into:
-    ```
-    skills/write-plan/
-    ├── SKILL.md                      # thin parent: orientation hub, when-to-use routing, shared conventions
-    ├── write-plan-setup/
-    │   └── SKILL.md                  # setup workflow only (scaffold planning tree)
-    ├── write-plan-expand/
-    │   └── SKILL.md                  # expand workflow only (deepen one group file)
-    ├── assets/
-    │   ├── implementation-plan.md    # copyable template (shared by both children)
-    │   ├── status-and-next-steps.md  # copyable template
-    │   └── task-group-skeleton.md    # copyable template
-    └── references/
-        └── structure.yaml           # updated: declares per-child output shapes
-    ```
-  - Parent SKILL.md: orientation + routing (like `explore/SKILL.md`, `research/SKILL.md`)
-  - `write-plan-setup/SKILL.md`: path detection, input modes, scaffolding workflow, behavioral contract for setup
-  - `write-plan-expand/SKILL.md`: group location, classify-and-rewrite workflow, behavioral contract for expand
-  - `assets/` stays in parent dir, shared by both children
-  - `references/structure.yaml` updated: separate `setup_output` and `expand_output` sections
+  - **Purpose:** Reduce per-invocation context by mirroring `explore/` + `research/` thin-parent ergonomics without losing shared YAML + asset contracts.
+  - **Steps:**
+    1. Relocate substantive Setup prose into `templates/standard-project/.claude/skills/write-plan/write-plan-setup/SKILL.md` with **`read ../SKILL.md`** gate (family conventions identical pattern to research children).
+    2. Move Expand procedural detail into sibling `write-plan-expand/SKILL.md` with analogous gate + classify matrix.
+    3. Replace legacy monolith `write-plan/SKILL.md` with **orientation-only** hub: diagrams, routing table to children, condensed path table, pointers to **`assets/`** + **`references/structure.yaml`**.
+    4. Enhance `references/structure.yaml`: add **`setup_output`** vs **`expand_output`** blocks describing mutability surfaces (singletons vs lone group markdown).
+    5. Sanity scan template consumers (e.g., **explore**/ **research**/ diagrams) referencing `/transition-plan` → modern **write-plan-*** naming.
+    6. Ensure FR-8: **no uncompensated reliance** on `.cursor/commands/*.md`; templates stay self-explaining (`write-plan-setup` Step 1 now references heuristic extraction only — no dangling command cites).
+  - **Files:** `templates/standard-project/.claude/skills/write-plan/**`; optional dependent skill parents (`explore/SKILL.md`, `research/SKILL.md`) for pipeline breadcrumb renaming only.
+  - **Acceptance:** Directory tree matches task diagram; YAML validates logically; parental hub matches explore/research tone; children independently deployable prose blocks.
+
+---
 
 - [ ] Task 9: Restructure decision skill with assets/ + references/
-  - Extract inline templates from `decision/SKILL.md` into `assets/`:
-    ```
-    skills/decision/
-    ├── SKILL.md                      # behavioral contract + workflow (reduced — no inline templates)
-    ├── assets/
-    │   ├── adr-template.md           # ADR section structure
-    │   ├── hub-readme-template.md    # decisions hub README scaffold
-    │   └── decision-interview.md     # interview scaffold template
-    └── references/
-        └── structure.yaml           # declares decision output shape (hub, ADRs, summary)
-    ```
-  - SKILL.md references `assets/` for file creation instead of embedding templates inline
-  - `references/structure.yaml` declares: singleton files (hub README, summary), collection files (ADRs), interview artifact
-  - Decision stays a single skill (no family split — one workflow mode), but gains the `assets/` + `references/` convention
+  - **Purpose:** Finish deferred template extraction from Group 1 — align decision with **`assets/` + `references/`** convention already proven on write-plan.
+  - **Steps:**
+    1. Create **`decision/assets/adr-template.md`**, **`hub-readme-template.md`**, **`decision-interview.md`** mirroring headings previously enumerated inline inside `SKILL.md`.
+    2. Slim `decision/SKILL.md`: retain workflow sequencing + behavioral contract/gotchas — replace embedded template literals with anchored references (`assets/…`, **`references/structure.yaml`** summaries).
+    3. Author **`decision/references/structure.yaml`** enumerating singletons (interview artifact, README hub, rollup summary), collections (`adr-NNN-*`), optional parent aggregator touch policy.
+    4. Confirm relative asset paths ergonomic from skill root (`assets/foo.md` wording).
+    5. Maintain five-property readability (Observables + failure branches still explicit despite slimmer SKILL).
+  - **Files:** `templates/standard-project/.claude/skills/decision/**`
+  - **Acceptance:** SKILL does not duplicate full scaffold fences; newcomers can generate artifacts solely by reading SKILL + copying assets/YAML cues.
+
+---
 
 - [ ] Task 10: Validate restructured skills
-  - Verify write-plan family: parent routes correctly, setup produces expected scaffolding, expand deepens correctly
-  - Verify decision: SKILL.md references assets instead of inline templates, structure.yaml is accurate
-  - Cross-check: `references/structure.yaml` for each skill accurately describes what the skill produces
-  - Run five-property rubric on all new/modified SKILL.md files
+  - **Purpose:** Guard cutover regressions ahead of Plan-Review (Group 4) + eventual command archival.
+  - **Steps:**
+    1. **Routing sanity:** Confirm parent forbids mistaken direct invocation wording consistent with explore/research parents (`disable-model-invocation`, explicit child routing).
+    2. **`structure.yaml` accuracy:** Tables in write-plan YAML must reflect filesystem behavior post-split; decision YAML mirrors actual workflow stages (interview-before-clustering invariant).
+    3. **Cross-pattern audit:** Explore/research parent diagrams reference **write-plan-setup** successor labels (not retired command names).
+    4. **Five-property rubric (FR-19) pass:** For each touched SKILL (`write-plan` parent + two children + `decision`), verify headings still encode *observable, bounded, outcome-framed, delta-only, failure-aware* obligations either in Behavioral Contract bullets or fused Gotchas (note gaps inline below if discovered).
+    5. Capture outcomes in **Validation notes** appended under this Task.
+  - **Files:** This task markdown (logging), enumerated skill + YAML artifacts above (read-only verification).
+  - **Acceptance:** Validation notes show GO with concrete references OR NO-GO with blocking defects listed (none expected if merge proceeds).
 
 ---
 
 ## 🎯 Goals
 
-1. **Align write-plan with the family pattern** — consistent with explore and research families; cleaner per-invocation context
-2. **Complete the `assets/` + `references/` convention** for decision (deferred from Group 1)
-3. **Validate that `structure.yaml` is accurate** for both restructured skills before plan-review conversion
+1. **Align write-plan with the family pattern** — parity with explore & research ergonomics while preserving deterministic planning artifacts.
+2. **Finish template externalization on decision** — eliminate monolithic scaffold duplication.
+3. **Prove YAML truth tables** precede downstream plan-review conversions.
 
 ---
 
@@ -77,10 +78,23 @@
 
 ## 🔗 Dependencies
 
-- **Depends on Group 2:** write-plan single skill must exist before restructuring into family
-- **Depends on Group 1:** decision skill must exist before adding assets/references
-- Restructuring here informs plan-review (Group 4) — plan-review can reference the family pattern and structure.yaml convention as established
+- **Depends on Group 2:** canonical single-pass write-plan SKILL existed before family split (**PR #93** landed baseline assets + YAML).
+- **Depends on Group 1:** authoritative behavioral decision workflow precedes templating refactor (**PR #92**).
+- Informs Group 4 (plan-review modernization) referencing updated family choreography.
 
 ---
 
-**Last Updated:** 2026-05-02
+## 📋 Validation notes (Task 10)
+
+_Add GO/NO-GO narrative after onsite verification._
+
+| Artifact | Spot-check | Verdict |
+|----------|-------------|---------|
+| `write-plan/SKILL.md` | Parent routing + duplication vs explore parent | Pending |
+| `write-plan-setup`, `write-plan-expand` | `read ../SKILL.md`; contracts + gotchas breadth | Pending |
+| `write-plan/references/structure.yaml` | `setup_output` vs `expand_output` coherence | Pending |
+| `decision/SKILL.md` | Asset pointers replace inline scaffolds | Pending |
+| `decision/references/structure.yaml` | Mirrors interview→hub→ADR→summary flow | Pending |
+| `explore` / `research` parents | Mention **write-plan-setup** not `/transition-plan` | Pending |
+
+**Rubric rollup:** Pending explicit tick-box commentary after reviewer pass.

--- a/templates/standard-project/.claude/skills/decision/SKILL.md
+++ b/templates/standard-project/.claude/skills/decision/SKILL.md
@@ -3,205 +3,146 @@ name: decision
 description: >-
   Create Architecture Decision Records from research: human decision-interview
   first, then one ADR per decision point with alternatives and rationale.
-  Use after research is complete and the user wants /decision or to record
-  topic decisions. Do NOT run planning/task implementation in this skill —
-  hand off to the project's planning workflow after ADRs exist.
+  Use after research is complete and the user wants /decision or ADR authoring.
+  Do NOT run implementation planning inside this skill — hand off afterwards.
 disable-model-invocation: true
 ---
 
 # Decision
 
-Make **documented architecture decisions** from research artifacts. **Hybrid
-skill:** procedural file scaffolding + behavioral judgment (decision framing,
-alternative quality, human pacing).
+Make **documented architecture decisions** from research artifacts using a staged
+workflow: constrained interview (**`assets/decision-interview.md`**) → hub index
+(**`assets/hub-readme-template.md`**) → ADR files seeded from **`assets/adr-template.md`**.
 
-**North star:** The user stays in control and enriched by slowing down — not
-rushed to a single “right answer” before priorities are explicit (see
-decision-interview pattern).
+Treat those files under `assets/` as **copy-on-write templates** beside the eventual
+disk paths declared in **`references/structure.yaml`**.
+
+Hybrid skill: scaffolding rules + deliberate behavioral judgment framing **options,
+not pre-baked mandates**.
+
+North star — users stay paced through explicit priority capture before narrowing to a
+recommended alternative set (see behavioral contract).
 
 ---
 
 ## When to use
 
-- Research outputs exist (summary + topic docs or equivalent) and the user
-  wants ADRs for a topic.
-- User says `/decision`, “decision command”, or “turn this research into ADRs”.
+- Research summaries + topic dossiers justify ADR-ready questions.
+- User says `/decision`, `/decisions`, or analogous natural language.
 
 ## When not to use
 
-- Research scaffolding is missing → point to **research-setup** first.
-- User only wants brainstorming without records → **discuss**.
-- User wants implementation tasks → **task** / planning pipeline, not this skill.
+- Research scaffolding missing substantive findings → **`research-setup`** instead.
+- Ideation wanting zero records → **`discuss`** until intent firms.
+- Need implementation task breakdown afterwards → **`write-plan-setup`** / execution flows.
 
 ---
 
 ## Path resolution
 
-Pick **one** row and use it consistently for `topic` (kebab-case slug):
+Pick **exactly one layout row**, stay scoped to that subtree for remainder:
 
-| Structure | Topic root | Decisions directory | Research summary (typical) | Requirements (typical) |
-|-----------|------------|--------------------|----------------------------|-------------------------|
-| Dev-Infra feature | `admin/services/[service]/features/[topic]/` | `[topic-root]/decisions/` | `research/research-summary.md` or under `research/` | `[topic-root]/requirements.md` or `research/requirements.md` |
-| Template maintainer | `docs/maintainers/` | `docs/maintainers/decisions/[topic]/` | `docs/maintainers/research/[topic]/research-summary.md` | `docs/maintainers/research/[topic]/requirements.md` |
-| Project-wide | `docs/maintainers/` | `docs/maintainers/decisions/[topic]/` | same as template row | same as template row |
+| Structure | Topic root | Decisions dir | Typical research pointers |
+|-----------|------------|---------------|---------------------------|
+| Dev-infra feature | `admin/services/[service]/features/[topic]/` | `[topic-root]/decisions/` | `research/research-summary.md`, `research/requirements.md` mirrors |
+| Template maintainer | `docs/maintainers/` | `docs/maintainers/decisions/[topic]/` | Matching `research/[topic]/` summaries |
+| Project-wide | `docs/maintainers/` | `docs/maintainers/decisions/[topic]/` | same as maintainer |
 
-**Do not** use `admin/decisions/[topic]/` for dev-infra feature work — that path
-conflicts with feature-local hubs; feature **`[topic]/decisions/`** is canonical.
+Do **not** route dev-infra feature work through `admin/decisions/[topic]/` hubs — feature-local
+`/decisions/` keeps traceability symmetrical with research siblings.
+
+Detailed glob expectations: **`references/structure.yaml`**.
 
 ---
 
-## Preconditions (stop if unmet)
+## Preconditions
 
-1. User supplies or confirms `topic` and at least one research path to read
-   (`--from-research` equivalent).
-2. After reading: if there are **no** findings and **no** stated decision
-   questions, **stop** — research is not ready.
+1. Human or agent declares `topic` + readable research corpus.
+2. After inspection: if summaries contain **zero** articulated decision questions &
+   unresolved constraints, STOP — escalate back to **`research-conduct`**.
 
 ---
 
 ## Workflow
 
-### 0. Decision interview (human priorities)
+### 0. Interview priorities
 
-**Goal:** Surface priorities, friction, and constraints **before** clustering
-decision points (phase start signal from agentic-workflow research).
+Goal: constrain sequencing before authoring ADRs.
 
-1. Compute `decisions/` directory for the topic from the table above.
-2. Interview artifact path: **`[decisions-dir]/decision-interview.md`**.
-3. If the file **does not exist**: offer to create a stub with sections modeled
-   on typical interview flow:
-   - **How to use** (short answers; skip ok)
-   - **User experience priorities** (which workflows matter; friction)
-   - **Constraints / instincts** (scope, risk, “v1 means…”)
-   - Optional: **architecture / validation** prompts  
-   Then **stop** until the user fills enough to guide clustering **or** types an
-   explicit in-chat waiver: e.g. `waive decision interview`.
-4. If the file **exists**: read it first; use it to order which decision clusters
-   to tackle and what tradeoffs are acceptable. If it is still marked awaiting
-   input and empty where it matters, **stop** and ask the user to complete or
-   waive.
+1. Resolve decisions directory (`…/decisions/` under topic root).
+2. Target path **`[decisions-dir]/decision-interview.md`**.
+3. If missing → copy tailoring instructions from **`assets/decision-interview.md`**, create file,
+   then STOP until human fills materially **or** types explicit textual waiver mirrored in-chat.
+4. If present but empty anchors remain → STOP with targeted prompts referencing missing sections.
 
-### 1. Load research and requirements
+### 1. Absorb research corpus
 
-1. Read `research-summary.md` (or equivalent) for the topic.
-2. Read per-topic research files linked from the hub or under `research/`.
-3. Read `requirements.md` when present (functional + non-functional).
-4. **Outputs:** mental model of constraints, findings, and candidate requirements
-   IDs to reference later.
+Sequential reads: hub README (if exists) → summary → dossiers → consolidated requirements.
 
-### 2. Identify decision points (cluster)
+Deliverable: prioritized unknown clusters + linkage map for rationales later.
 
-For each cluster of related unknowns:
+### 2. Identify decision clusters
 
-1. Name **one** decision question (one ADR per decision point later).
-2. List **2–3 alternatives** with **pros/cons** — **do not** present a single
-   recommended winner until the user chooses or defers (see Behavioral
-   Contract).
-3. Note decision criteria (e.g. portability, complexity, team size).
+For cluster:
 
-**Observable output:** Ordered list of decision points (titles only) shown to
-the user; User confirms order or edits before file writes.
+1. One crisp question headline (will map 1:1 to ADRs).
+2. At least **two** differentiated alternatives annotated with +/- trade space.
+3. Criteria tags (risk, portability, staffing, rollout windows).
 
-### 3. Create or update decisions hub README
+Expose ordered backlog to operator for ACK before writes.
 
-In `[decisions-dir]/README.md`:
+### 3. Maintain decisions hub README
 
-- Purpose: decisions hub for topic; links to research + requirements.
-- Table listing each ADR with status (Proposed until user accepts).
-- `decisions-summary.md` link.
+Seed / refresh using **`assets/hub-readme-template.md`** — emphasize links table + statuses.
 
-Use the project's status emoji conventions if already present; otherwise 🔴 /
-🟡 / ✅ as in existing docs.
+### 4. Author ADRs (one file per outstanding decision)
 
-### 4. Write ADRs (one file per decision point)
+Filename pattern `adr-[NNN]-[kebab].md` synced with numbering policy in **`references/structure.yaml`**.
 
-**Filename:** `adr-[NNN]-[kebab-name].md` in `[decisions-dir]/`,
-zero-padded numbering matching hub order.
+Structural obligations mirror **`assets/adr-template.md`** (Context, Decision, Consequences ±,
+Alternatives, Rationale bridging interview, Requirements impact, References). Default lifecycle
+starts **🔴 Proposed** pending owner acceptance gates.
 
-**Required sections (non-negotiable):**
+### 5. Maintain `decisions-summary.md`
 
-1. **Context** — problem, forces, links to research + requirements.
-2. **Decision** — clear decision statement.
-3. **Consequences** — Positive and Negative subsections.
-4. **Alternatives Considered** — at least two, each with pros/cons and **why not
-   chosen** (or “deferred” with reason).
-5. **Decision Rationale** — ties back to interview priorities and research.
-6. **Requirements Impact** — affected/refined requirements.
-7. **References** — research paths, interview file if used.
+One-screen synopsis cross-linking statuses + fallout for PM stakeholders.
 
-**Status:** start as **Proposed** unless the user directs otherwise.
+### 6. Touch parent README only if precedent exists
 
-### 5. Create `decisions-summary.md`
+Prefer append-only hyperlink entries when repos already maintain aggregator docs (see YAML map).
 
-Summarize each ADR in one screen: decision one-liner, status, link. Requirements
-impact at high level, pointer to full `requirements.md`.
+### 7. Commit guidance — bounded autonomy
 
-### 6. Update parent decisions index (if present)
-
-| Structure | Parent index |
-|-----------|----------------|
-| Template / project-wide | `docs/maintainers/decisions/README.md` |
-| Dev-Infra | `admin/decisions/README.md` **or** service hub if that is where the repo lists decision topics — use whichever file already lists other topics. If none exists, skip (do not invent org-wide policy). |
-
-Add the topic link only if that file exists and is the established pattern.
-
-### 7. Commit guidance (bounded)
-
-1. Propose a single commit or small series with message shape:
-   `docs(decisions): add [topic] ADRs` (or per-ADR if user prefers).
-2. List `git add` paths concretely.
-3. **Stop.** Do not merge to a branch unless the user's repository policy asks —
-   the old command's merge-to-develop flow is not universal.
+Recommend `git add …` coverage + concise `docs(decisions):` style commit message bodies; STOP before
+automatic merges lacking policy certainty.
 
 ---
 
-## Behavioral Contract
+## Behavioral contract
 
-**Options, not answers.** Until the user selects or explicitly defers, present
-**2–3** credible alternatives with tradeoffs for each decision point. A
-recommended default is allowed **only** if the user asks for a recommendation
-after seeing alternatives.
+- **Options dominance:** forbid single-path ADRs posing as exhaustive unless research logged why.
+- **One decision per ADR.** Bundle only tightly coupled deltas with explicit bridging narrative.
+- **Traceability enforced:** citations must be openable Markdown-relative paths audiences already trust.
+- **Interview gravity:** waived flows must visibly echo waiver text inside ADRs (no invisible skips).
+- **Bounded analysis:** once mandatory sections materially satisfied → yield to human approval loops.
+- **Failure-aware:** conflicting numbering / hub divergence → escalate with corrective menu (append /
+  resequence / reconcile) before overwriting.
 
-**One ADR per decision point.** Do not combine unrelated decisions in one ADR.
-
-**Traceability.** Each ADR's Context and References must include paths the reader
-can open — no orphan decisions.
-
-**Interview informs rationale.** The `decision-interview.md` content (or waiver)
-must visibly influence **Decision Rationale** and ordering — if not, you skipped
-the point of step 0.
-
-**Bounded analysis.** Enough analysis to distinguish alternatives; stop when
-sections are complete and consistent. Do not continue into implementation
-planning.
-
-**Failure-aware.** If paths conflict or hub already exists with different
-numbering, **pause** and ask whether to append, renumber, or align with existing
-ADRs.
+Observable / bounded / outcome-framed / delta-only interpretations align with Stage 3 five-property gate.
 
 ---
 
 ## Gotchas
 
-**Wrong dev-infra root.** Using a global `admin/decisions/[topic]/` path for
-feature work breaks links; use `admin/services/.../features/[topic]/decisions/`.
+- Mis-targeting **`admin/decisions/`** hubs for bounded feature scopes — breaks onboarding paths.
+- Silent interview skips — yields mis-prioritized ADR waterfalls.
+- **Placeholder ADRs** masquerading as finished — placeholders belong in drafts branches only.
+- Merged winner hallucination — rewind to enumerated trade space if critique absent.
+- **Planning bleed:** never mint `implementation-plan.md` herein — escalate to **`write-plan-setup`**.
 
-**Skipping interview silently.** Without priorities, decision order defaults to
-technical completeness — that violates the interview-first pattern; only proceed
-with an explicit waiver.
-
-**Single-option ADRs.** An ADR with one “alternative” is incomplete — fold more
-options in or document why others were eliminated in research.
-
-**Paste-only ADRs.** Filling the template with placeholders and lorem-style
-text — each section needs substantive ties to **this** topic's research.
-
-**Merged recommendations.** If you “hallucinate” a decision the user did not
-accept, rewind: alternatives first, then record their choice.
-
-**Planning bleed.** Do not create `implementation-plan.md` here — that belongs
-to the planning / write-plan step after ADRs stabilize.
+Asset pointers keep templates versioned beside skill instructions for FR-8 self-containment.
 
 ---
 
-**Last Updated:** 2026-05-02
+**Structured map:** `references/structure.yaml`  
+**Interview seed:** `assets/decision-interview.md` • **Hub seed:** `assets/hub-readme-template.md` • **ADR seed:** `assets/adr-template.md`

--- a/templates/standard-project/.claude/skills/decision/assets/adr-template.md
+++ b/templates/standard-project/.claude/skills/decision/assets/adr-template.md
@@ -1,0 +1,57 @@
+# ADR-NNN: {Decision Title}
+
+**Status:** 🔴 Proposed  
+**Decision topic:** `{topic-kebab}`
+
+---
+
+## Context
+
+Explain the unresolved tension, cite research paths (non-empty). Link requirements IDs
+touching scope when known.
+
+---
+
+## Decision
+
+Concise decisive statement answering *what* happens next.
+
+---
+
+## Consequences
+
+### Positive
+
+-
+
+### Negative
+
+-
+
+---
+
+## Alternatives Considered
+
+Document **≥2** distinct options unless research already eliminated contenders (call that fact out explicitly).
+
+Each alternative captures tradeoffs plus **why not chosen now** vs **deferred** with reasoning.
+
+---
+
+## Decision Rationale
+
+Must tie priorities from `assets/decision-interview.md` (copied beside this ADR in the hub)
+unless the waived interview note lives in-chat and is mirrored verbatim here.
+
+---
+
+## Requirements Impact
+
+List requirement IDs strengthened/relaxed/added; note orphaned requirements redirected for follow-on work.
+
+---
+
+## References
+
+Absolute/relative Markdown links humans can immediately open (`research-summary.md`,
+per-topic dossiers, interview snapshot, dashboards, etc.)

--- a/templates/standard-project/.claude/skills/decision/assets/decision-interview.md
+++ b/templates/standard-project/.claude/skills/decision/assets/decision-interview.md
@@ -1,0 +1,40 @@
+# Decision Interview — `{topic-kebab}`
+
+Human priorities **before** clustering decision points into ADRs. Replace `{topic-kebab}`
+if you rename the slug.
+
+**Status:** 🔴 Awaiting input *(update when ready for clustering — or annotate explicit waiver in ADRs)*
+
+---
+
+## How to use
+
+Prefer short bullets; skip prompts that genuinely do not apply. The agent should
+still **STOP** early if priorities + constraints remain empty unless the operator
+explicitly sends a textual waiver (`waive decision interview` equivalent).
+
+---
+
+## User experience priorities
+
+- Which workflows must feel meaningfully improved in the upcoming release slice?
+- What friction reliably escalates incidents or rework today?
+
+---
+
+## Constraints / instincts
+
+- Non-negotiable scope cuts ("never in v1", compliance walls, mandated stacks)
+- Architectural risk appetite (prefers incremental vs bold refactors)
+
+---
+
+## Optional — architecture / validation prompts
+
+- Latency / sizing instincts someone should sanity-check before debating alternates?
+- Operational requirements (deployment cadence, audit logging, tenancy, etc.)
+
+---
+
+Agents must reference this file (`decisions/decision-interview.md` for typical layouts)
+inside each ADR’s **Decision Rationale** whenever content here influenced ordering.

--- a/templates/standard-project/.claude/skills/decision/assets/hub-readme-template.md
+++ b/templates/standard-project/.claude/skills/decision/assets/hub-readme-template.md
@@ -1,0 +1,35 @@
+# Decisions Hub — `{Topic readable title}`
+
+**Purpose:** Index every Architecture Decision Record for `{topic-kebab}`, linking outward
+to research summaries, requirements extracts, and the decision interview artifact.
+
+Replace `{topic-kebab}` consistently with sanitized naming (hyphen-separated lowercase).
+
+---
+
+## Linked inputs
+
+| Artifact | Typical location |
+|-----------|------------------|
+| Research summary | `research/research-summary.md` *(adjust depth if mirrored elsewhere)* |
+| Requirements | `${topic-root}/requirements.md` OR `research/requirements.md` |
+| Decision interview | `./decision-interview.md` |
+
+---
+
+## ADR index
+
+Maintain a Markdown table naming each planned/proposed/completed ADR file.
+
+| File | Decision (one sentence) | Status |
+|------|--------------------------|--------|
+| `adr-001-example-topic.md` | … | 🔴 Proposed |
+
+Use your repository’s emoji legend if documented; fallback: 🔴 Proposed • 🟡 Under review • ✅ Accepted • ⚫ Superseded.
+
+---
+
+## Supporting summary checklist
+
+Once multiple ADRs exist, keep **`decisions-summary.md`** synced so humans can skim without
+opening every lengthy document.

--- a/templates/standard-project/.claude/skills/decision/references/structure.yaml
+++ b/templates/standard-project/.claude/skills/decision/references/structure.yaml
@@ -34,5 +34,7 @@ outputs:
     - filename: decisions/decisions-summary.md
       role: One-screen rollup of ADR intents + requirements fallout
   optional_parent_index_updates:
-    - filename: docs/maintainers/decisions/README.md OR admin/decisions/README.md
-      role: Mention topic iff file already establishes cross-topic navigation
+    - filename: docs/maintainers/decisions/README.md
+      role: Mention topic only if file already lists cross-topic navigation
+    - filename: admin/decisions/README.md
+      role: Mention topic only if file already lists cross-topic navigation

--- a/templates/standard-project/.claude/skills/decision/references/structure.yaml
+++ b/templates/standard-project/.claude/skills/decision/references/structure.yaml
@@ -1,0 +1,38 @@
+# Decision skill — declared outputs alongside assets/ templates.
+schema_version: 1
+skill: decision
+
+input_modes_expected:
+  - id: from_research
+    description: Research tree complete enough to articulate decision questions
+    notes: Mirrors legacy `/decision --from-research` intent
+
+planning_roots:
+  dev_infra_feature:
+    base_glob: "admin/services/{service}/features/{topic}/"
+    decisions_relative: decisions/
+    research_relative: research/
+  template_project:
+    base_glob: "docs/maintainers/decisions/{topic}/"
+    research_glob_hint: "docs/maintainers/research/{topic}/"
+
+outputs:
+  singletons_interview_first:
+    - filename: decisions/decision-interview.md
+      role: Structured human interview stub (copied/adapted from assets/decision-interview.md)
+      created_before_clustering: true
+  singletons_hub:
+    - filename: decisions/README.md
+      role: ADR hub + status table seeded from assets/hub-readme-template.md
+  collections_adrs:
+    - pattern: "decisions/adr-{nnn}-{kebab-summary}.md"
+      role: One ADR per decision point seeded from assets/adr-template.md
+      numbering_rule: >-
+        Leading zero-padded NNN matching lexical hub ordering; increments when inserting
+        new ADRs unless maintainers prescribe otherwise.
+  singleton_summary:
+    - filename: decisions/decisions-summary.md
+      role: One-screen rollup of ADR intents + requirements fallout
+  optional_parent_index_updates:
+    - filename: docs/maintainers/decisions/README.md OR admin/decisions/README.md
+      role: Mention topic iff file already establishes cross-topic navigation

--- a/templates/standard-project/.claude/skills/explore/SKILL.md
+++ b/templates/standard-project/.claude/skills/explore/SKILL.md
@@ -14,7 +14,7 @@ Organize unstructured thoughts into themed explorations with prioritized
 research questions. This is the entry point of the thinking pipeline:
 
 ```
-explore-start → (human review) → research → decision → transition-plan → task
+explore-start → (human review) → research → decision → write-plan-setup → task
                       ↑
           explore-amend (feedback loop from downstream)
 ```

--- a/templates/standard-project/.claude/skills/research/SKILL.md
+++ b/templates/standard-project/.claude/skills/research/SKILL.md
@@ -14,7 +14,7 @@ Structured research from exploration or reflection through requirements ready
 for decisions. This family replaces the multi-mode `/research` command:
 
 ```
-research-setup → (human review) → research-conduct → (human review) → research-consolidate → /decision → /transition-plan
+research-setup → (human review) → research-conduct → (human review) → research-consolidate → /decision → write-plan-setup
          ↑
     explore output & explore-amend (new topics in research-topics.md)
 ```
@@ -100,5 +100,5 @@ research directory until a future naming cleanup.
 ## Related
 
 - **Upstream:** explore → `research-topics.md`
-- **Downstream:** `/decision --from-research`, `/transition-plan --from-adr`
+- **Downstream:** `/decision --from-research`, **write-plan-setup** (`--from-adr` semantics)
 - **Lateral:** **explore** family for exploration paths and amend loop

--- a/templates/standard-project/.claude/skills/write-plan/SKILL.md
+++ b/templates/standard-project/.claude/skills/write-plan/SKILL.md
@@ -1,41 +1,40 @@
 ---
 name: write-plan
 description: >-
-  Create or expand implementation planning documents (implementation-plan.md,
-  status-and-next-steps.md, tasks/) from ADRs, artifacts, reflection output, or
-  design docs. Setup mode scaffolds the tree; Expand mode deepens one task group.
-  Use when the user wants /transition-plan, planning scaffolding, or to expand a
-  planning group. Read references/structure.yaml for output shape; copy templates
-  from assets/ rather than inventing filenames.
+  Write-plan skill family parent. Orientation and shared conventions for scaffolding
+  and expanding implementation plans. Do NOT invoke directly — use write-plan-setup
+  (scaffold planning tree) or write-plan-expand (deepen one group file). Children
+  should read this file first for path rules and contracts.
 disable-model-invocation: true
 ---
 
-# Write-Plan
+# Write-Plan — Skill Family
 
-Replace the `/transition-plan` command with a **two-phase skill**: **Setup**
-(scaffold planning tree) and **Expand** (add detail to one group file). Both
-phases share path detection, YAML frontmatter rules, and output layout — see
-`references/structure.yaml`.
+Create or evolve **uniform planning trees** (`implementation-plan.md`,
+`status-and-next-steps.md`, `tasks/`) sourced from ADRs, artifacts, reflections,
+or design docs. Mirrors the retired `/transition-plan` command as two focused
+skills so each invocation carries less procedural surface area.
 
----
+```
+write-plan-setup → (human review of scaffolding) → write-plan-expand → (repeat expand) → execution workflow
+```
 
-## When to use
+## Available Skills
 
-- After decisions or design work and the user wants an actionable task plan.
-- User says `/transition-plan`, “scaffold implementation plan”, “expand group N”.
-- Staged work needs `planning/…` or `planning-stageN/…` under a feature.
+| Skill | When to use |
+|-------|-------------|
+| **write-plan-setup** | **Setup mode:** scaffold `implementation-plan.md`, `status-and-next-steps.md`, and skeletized `tasks/NN-group.md` files |
+| **write-plan-expand** | **Expand mode:** turn one scaffolding group file into detailed steps / acceptance criteria |
 
-## When not to use
+## Family Conventions
 
-- No source material (ADR, artifact, reflection, or design) agreed — gather
-  inputs first.
-- Only code changes, no planning tree — use implementation tasks, not this skill.
+Child skills live in `write-plan-setup/` and `write-plan-expand/`. Before running a
+workflow, **`read ../SKILL.md`** in that child loads this orientation (path detection,
+templates location, parity rules).
 
----
+### Path Detection
 
-## Path detection
-
-Pick **one** planning root and use it for the whole invocation:
+Pick **one** planning root and use it for the whole subtree:
 
 | Layout | Planning root |
 |--------|----------------|
@@ -44,96 +43,39 @@ Pick **one** planning root and use it for the whole invocation:
 
 **Staged planning:** If the feature already uses `planning-stage2/`, `planning-stage3/`, etc., create **sibling** directories — do not silently merge into an old stage without user confirmation.
 
-**Detection:** If `admin/services/` applies, prefer feature-local paths. Otherwise use maintainer docs layout. Document the chosen subdirectory in `status-and-next-steps.md` Notes.
+**Detection:** If `admin/services/` applies in the repo, prefer the dev-infra layout row. Otherwise use the maintainer-docs row. Record the chosen subdirectory in `status-and-next-steps.md` Notes.
 
----
+Details and `{N}` semantics: `references/structure.yaml` (`planning_roots`).
 
-## Preconditions (stop if unmet)
+### Shared Preconditions
 
-1. **Topic / feature name** is known or inferable from context.
-2. **Input mode** identified: `from_adr` | `from_artifacts` | `from_reflection` | `from_design`.
-3. Source paths exist and are readable.
+1. **Topic / feature name** is known or inferable.
+2. **Input mode** is identified (`from_adr` | `from_artifacts` | `from_reflection` | `from_design`) — see child skills.
+3. Source paths exist and are readable — or the workflow stops with options.
 
----
+### Templates and Contract
 
-## Input modes
+- **Copy, do not reinvent filenames:** templates live in `assets/` beside this file.
+- **Declarative I/O:** `references/structure.yaml` is the authoritative map of Setup vs Expand outputs (`setup_output`, `expand_output`).
+- **Frontmatter parity:** `task_count`, `groups[]`, `tasks_files[]`, and body checkboxes must stay consistent across Setup and Expand (Expand never drops the plan root).
 
-| Mode | Read |
-|------|------|
-| **from_adr** | ADR files under `decisions/…`; optional `research/…/requirements.md` |
-| **from_artifacts** | Given artifact (checklist, handoff doc, transition brief) |
-| **from_reflection** | Reflection doc; if project expects generated artifacts first, surface that dependency |
-| **from_design** | `design.md` or Section excerpts: goals, stages, open questions → task groups |
+### Commit Discipline
 
-Extract: decisions, requirements, success criteria, constraints, and suggested group boundaries.
+Planning artifacts are documentation. Prefer `docs([feature]):` or the host repo’s planner scope; avoid merging unless policy requires it.
 
----
+## When NOT to Use This Family
 
-## Setup workflow
-
-**Goal:** Create `implementation-plan.md`, `status-and-next-steps.md`, and
-`tasks/NN-group-slug.md` skeletons.
-
-1. **Load sources** per Input modes above.
-2. **Choose transition type:** feature (default), release (source path or content mentions release/version), or ci-cd if pipeline-only scope.
-3. **Organize task groups:** 2–8 tasks per group; **global** task numbering 1…N across all groups; kebab-case group filenames.
-4. **Author `implementation-plan.md`:**
-   - YAML frontmatter: `task_count`, `groups` (name, file, task ids), `tasks_files`.
-   - Body: checkbox list matching `task_count` exactly. See `assets/implementation-plan.md`.
-5. **Author `status-and-next-steps.md`:** progress table + next steps. See `assets/status-and-next-steps.md`.
-6. **Author each `tasks/NN-….md`:** copy `assets/task-group-skeleton.md`; fill titles and one-line hints only (**no** long TDD blocks yet). Header `**Status:** 🔴 Scaffolding (needs expansion)`.
-7. **Commit guidance:** suggest `docs([feature]): …` or project convention; do not require dev-infra-specific branch polish unless the repo uses it.
-
----
-
-## Expand workflow
-
-**Goal:** One group file gains detailed steps, acceptance criteria, and files.
-
-**Trigger:** User specifies group index (1-based) or group name; optional `--all` for small plans only.
-
-1. **Locate group file** from frontmatter `groups[].file`.
-2. **Verify status** is scaffolding. If already `✅ Expanded`, skip or re-expand only on explicit request.
-3. **Classify group type** for order of detail:
-   | Type | Order |
-   |------|-------|
-   | Code + tests | RED → GREEN → REFACTOR in task text |
-   | Scripts | tests → script → integration |
-   | Docs / planning only | outline → link → verify |
-4. **Rewrite each task** with Purpose, Steps/TDD, Files, Acceptance.
-5. **Update header:** `**Status:** ✅ Expanded`; remove scaffolding banner.
-6. **Commit** with a scoped message describing the expanded group.
-
----
-
-## Behavioral contract
-
-- **Observable:** Every task checkbox in `implementation-plan.md` maps to exactly one row in a group file; filenames match `tasks_files`.
-- **Bounded:** If multiple features match, **stop** and ask which `feature/` directory; do not guess across unrelated features.
-- **Outcome-framed:** Deliver files under the chosen planning root; use templates in `assets/`.
-- **Delta-only:** Do not paste full multi-hundred-line templates into chat — **copy from `assets/`** on disk.
-- **Failure-aware:** Missing requirements, missing source, or existing `implementation-plan.md` → surface options (abort, new stage dir, `--force` if project allows).
-
----
-
-## Gotchas
-
-1. **Frontmatter must match body:** `task_count` equals checkbox count; `groups[].tasks` partition 1…N.
-2. **Expand is not Setup:** never delete `implementation-plan.md` when expanding a group.
-3. **`from_reflection` chaining** may depend on another workflow producing artifacts — call that out instead of inventing content.
-4. **Release transitions** reuse the **same file shapes**; only grouping semantics change.
-5. **`--all` expand** is context-heavy — prefer one group at a time for N > 3 groups.
-6. **Staged dirs:** dev-infra Stage 3 uses `planning-stage3/` not `planning/`; mirror sibling pattern the feature already uses.
-
----
+| Situation | Use instead |
+|-----------|-------------|
+| No agreed source material | Gather ADRs / design first (**decision**, upstream research) |
+| Only code churn, no plan files | Implementation task workflows |
+| Plan already fully expanded | Execute tasks — do not rescaffold |
 
 ## Related
 
 - **decision** — upstream ADRs.
-- **plan-review** — validate plan before execution.
-- Source command archived in dev-infra: `.cursor/commands/transition-plan.md`.
+- **plan-review** — validate plan consistency before execution.
+- **research / explore** — earlier pipeline stages feeding planning inputs.
 
----
-
-**Canonical shape:** `references/structure.yaml`  
-**Copyable templates:** `assets/implementation-plan.md`, `assets/status-and-next-steps.md`, `assets/task-group-skeleton.md`
+**Canonical shapes:** `references/structure.yaml`  
+**Templates:** `assets/implementation-plan.md`, `assets/status-and-next-steps.md`, `assets/task-group-skeleton.md`

--- a/templates/standard-project/.claude/skills/write-plan/references/structure.yaml
+++ b/templates/standard-project/.claude/skills/write-plan/references/structure.yaml
@@ -61,8 +61,8 @@ expand_output:
       role: Exactly one group's markdown deepened per run (Purpose/Steps/Acceptance)
       promoted_status_when_complete: "✅ Expanded"
   singletons_touch_policy: >
-    Rare advisory edits only (never delete implementation-plan.yaml block); root files
-    should already exist before expand executes.
+    Rare advisory edits only (never strip the YAML frontmatter block inside
+    implementation-plan.md); root files should already exist before expand executes.
 
 # Shared layout reference (historic outputs block — identical coverage to setup + expand slices).
 outputs:

--- a/templates/standard-project/.claude/skills/write-plan/references/structure.yaml
+++ b/templates/standard-project/.claude/skills/write-plan/references/structure.yaml
@@ -1,10 +1,13 @@
 # Declarative contract for write-plan skill outputs and inputs.
-# Human and agent readers: use this alongside SKILL.md for path and shape truth.
+# Human and agent readers: use this alongside parent + child SKILL.md files.
 
-schema_version: 1
+schema_version: 2
 skill: write-plan
+family_members:
+  - write-plan-setup
+  - write-plan-expand
 
-# Logical input channels (mirror command flags; design.md may be used like artifacts).
+# Logical input channels (mirror legacy command flags; design.md usable as pseudo-artifacts).
 input_modes:
   - id: from_adr
     description: ADR directory or files under decisions/
@@ -20,21 +23,48 @@ input_modes:
     typical_flags: ["--from-design"]
     notes: Natural extension for Stage 3-style planning sourced from design.md
 
-# Where the planning tree is rooted on disk (one of these conventions per repo).
+# Where the planning tree is rooted on disk (one convention per invocation).
 planning_roots:
   dev_infra_feature:
     description: Feature work under admin/services
     base_glob: "admin/services/{service}/features/{feature}/"
     default_subdir: planning
-    # N is a 1-based positive integer (1, 2, 3, …). Directory name is literal prefix
-    # "planning-stage" + decimal digits (no zero-padding required): planning-stage3, planning-stage12, etc.
     staged_planning_subdir_pattern: "planning-stage{N}/"
-    notes: Stage 3 of this feature uses planning-stage3/ instead of planning/
+    notes: |
+      N is a 1-based positive integer (1, 2, 3, …). Directory name is literal prefix
+      "planning-stage" plus decimal digits (no zero-padding required): planning-stage3,
+      planning-stage12, etc.
   template_project:
     description: Maintainer docs layout in generated projects
     base_glob: "docs/maintainers/planning/features/{feature}/"
 
-# Files the skill creates or updates (Setup and Expand).
+# Produced/updated artifacts by invocation (skills: write-plan-setup vs write-plan-expand).
+setup_output:
+  skill_invocation: write-plan-setup
+  creates_or_replaces_safe_scaffolding_only: true
+  directories:
+    - path: tasks
+      role: One markdown file per task group (initial skeleton)
+      naming: "{nn}-{group-slug}.md"
+  singletons:
+    - filename: implementation-plan.md
+      role: YAML frontmatter + checkbox task index matching task_count
+    - filename: status-and-next-steps.md
+      role: Empty/progress scaffolding + scripted next milestones
+  group_file_initial_status: "🔴 Scaffolding (needs expansion)"
+
+expand_output:
+  skill_invocation: write-plan-expand
+  mutates_collections_only: true
+  collections:
+    - pattern: "tasks/{target-group-md}"
+      role: Exactly one group's markdown deepened per run (Purpose/Steps/Acceptance)
+      promoted_status_when_complete: "✅ Expanded"
+  singletons_touch_policy: >
+    Rare advisory edits only (never delete implementation-plan.yaml block); root files
+    should already exist before expand executes.
+
+# Shared layout reference (historic outputs block — identical coverage to setup + expand slices).
 outputs:
   directories:
     - path: tasks
@@ -53,16 +83,16 @@ outputs:
       setup_status: "🔴 Scaffolding (needs expansion)"
       expanded_status: "✅ Expanded"
 
-# Frontmatter contract (must match implementation-plan body checkboxes).
 implementation_plan_frontmatter:
   required_keys:
     - task_count
     - groups
     - tasks_files
-  # Consistency: tasks_files must be the ordered list of `groups[].file` values in the same
-  # order as `groups` (each path appears exactly once). groups[].tasks lists global task IDs
-  # 1..task_count covered by that group’s checkboxes in the body.
   group_entry_shape:
     name: string
     file: string
     tasks: list_of_integers
+  tasks_files_must_match_groups: >
+    tasks_files MUST list groups[].file in the SAME order as groups[]; each declared
+    file occurs exactly once. groups[].tasks enumerates global task IDs owned by that
+    group's markdown checkboxes without gaps across the union of all groups.

--- a/templates/standard-project/.claude/skills/write-plan/write-plan-expand/SKILL.md
+++ b/templates/standard-project/.claude/skills/write-plan/write-plan-expand/SKILL.md
@@ -2,8 +2,9 @@
 name: write-plan-expand
 description: >-
   Expand one scaffolding task-group file with detailed Purpose, Steps/TDD, Files,
-  and Acceptance criteria. Mirrors Expand mode of retired /transition-plan.
-  Read ../SKILL.md first. Does not recreate implementation-plan roots.
+  and Acceptance criteria. Primary skill: **write-plan-expand**; legacy alias
+  `/transition-plan … --expand` maps here. Read ../SKILL.md first. Does not
+  recreate implementation-plan roots.
 disable-model-invocation: true
 ---
 
@@ -41,7 +42,7 @@ Before proceeding, **`read ../SKILL.md`** for path rules and frontmatter parity.
 
 **Goal:** One group file earns full operational detail — still markdown only.
 
-**Trigger cues:** `/transition-plan [feature] --expand --group N`, natural language equivalents.
+**Trigger cues:** **write-plan-expand** with `--group N`; legacy `/transition-plan [feature] --expand --group N`; or natural-language equivalents.
 
 1. **Resolve target** by numeric index mapping into `groups[]` OR fuzzy title match
    confirmed with operator.
@@ -51,10 +52,10 @@ Before proceeding, **`read ../SKILL.md`** for path rules and frontmatter parity.
    | Type | Order inside each task row |
    |------|----------------------------|
    | Code + automated tests | RED → GREEN → REFACTOR phrasing inside Steps |
-   | Scripts / tooling | bats → script → integration |
+   | Scripts / tooling | Bats (Bash Automated Testing System) tests → script → integration |
    | Docs / coordination | outline → link → verify reads |
 5. **Rewrite each `- [ ] Task …` block** adding **Purpose**, **Steps or TDD Flow**,
-   **Files**, **Acceptance** per transition-plan Expand guidance.
+   **Files**, **Acceptance** per this skill’s Expand quality bar (aligns with **write-plan**/transition-plan-era guidance).
 6. **Header flip:** replace `🔴 Scaffolding` with **`✅ Expanded`; remove scaffolding callout**.
 7. **Commit:** scoped message documenting which group absorbed detail.
 

--- a/templates/standard-project/.claude/skills/write-plan/write-plan-expand/SKILL.md
+++ b/templates/standard-project/.claude/skills/write-plan/write-plan-expand/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: write-plan-expand
+description: >-
+  Expand one scaffolding task-group file with detailed Purpose, Steps/TDD, Files,
+  and Acceptance criteria. Mirrors Expand mode of retired /transition-plan.
+  Read ../SKILL.md first. Does not recreate implementation-plan roots.
+disable-model-invocation: true
+---
+
+# Write-Plan Expand
+
+Before proceeding, **`read ../SKILL.md`** for path rules and frontmatter parity.
+
+---
+
+## When to use
+
+- A planning tree exists with `🔴 Scaffolding` group headers.
+- User specifies **group index (1-based)** or **matching group title**, or narrowly
+  scopes `--all` for tiny plans only.
+- After human review agrees skeleton structure is sane.
+
+## When not to use
+
+- **Setup never ran** — impossible to locate `groups[]` pointers.
+- Destructive regen requested without **`--force` / repo policy**.
+- Operational coding only — unrelated to deepening markdown planning tasks.
+
+---
+
+## Preconditions (stop if unmet)
+
+1. `implementation-plan.md` readable with YAML `groups`, `tasks_files`,
+   coherent `task_count`.
+2. Target group file resolved from frontmatter (`groups[].file`).
+3. That file exists and banner shows scaffolding (`🔴`), unless caller explicitly re-expands.
+
+---
+
+## Expand workflow
+
+**Goal:** One group file earns full operational detail — still markdown only.
+
+**Trigger cues:** `/transition-plan [feature] --expand --group N`, natural language equivalents.
+
+1. **Resolve target** by numeric index mapping into `groups[]` OR fuzzy title match
+   confirmed with operator.
+2. **Open file** (`tasks/NN-….md`).
+3. **Status gate:** scaffolding expected. Already `✅ Expanded` ⇒ skip unless user forces.
+4. **Classify cohort** — sets how each task subsection is authored:
+   | Type | Order inside each task row |
+   |------|----------------------------|
+   | Code + automated tests | RED → GREEN → REFACTOR phrasing inside Steps |
+   | Scripts / tooling | bats → script → integration |
+   | Docs / coordination | outline → link → verify reads |
+5. **Rewrite each `- [ ] Task …` block** adding **Purpose**, **Steps or TDD Flow**,
+   **Files**, **Acceptance** per transition-plan Expand guidance.
+6. **Header flip:** replace `🔴 Scaffolding` with **`✅ Expanded`; remove scaffolding callout**.
+7. **Commit:** scoped message documenting which group absorbed detail.
+
+---
+
+## Classify-and-rewrite rules
+
+1. Maintain **checkbox ↔ global task numbering** parity with sibling rows in implementation-plan.md.
+2. Do **not** delete sibling group files nor shrink `tasks_files`.
+3. If group mixes types, tag each bullet cluster — readers may split later downstream.
+4. Prefer linking long reference URLs instead of pasting verbatim upstream PDFs/logs.
+
+---
+
+## Behavioral contract
+
+- **Observable:** After expand, reviewer can trace each implementation-plan checkbox bullet
+  to explicit acceptance language in-group.
+- **Bounded:** Exactly one group's primary prose mutates unless `--all` miniature plan flagged.
+- **Outcome-framed:** Deliver updated group markdown plus suggested commit skeleton.
+- **Delta-only:** Minimize duplication of YAML spec — cite frontmatter truths instead.
+- **Failure-aware:** Structural mismatch (`task_count`), missing scaffolding, contradictory IDs
+   → STOP with diff summary suggestion.
+
+---
+
+## Gotchas
+
+1. Expand ≠ Setup — never wipe `implementation-plan.md` accidentally during polish passes.
+2. Large programs (many groups): avoid `--all` — expansion context balloon risk.
+3. Emoji / status cues must mirror house style from template assets (`status-and-next-steps`).
+4. Staging drift: verifying `tasks_files[]` unchanged catches silent renames mid-expand.
+5. Cross-stage repos: expanding wrong `planning-stageN` folder orphaned from active work.
+
+---
+
+## Related
+
+- **write-plan-setup** — prerequisite skeleton emission.
+- **plan-review** — consistency audit post-expansion bursts.
+- Output focus: **`../references/structure.yaml`** (`expand_output`).

--- a/templates/standard-project/.claude/skills/write-plan/write-plan-setup/SKILL.md
+++ b/templates/standard-project/.claude/skills/write-plan/write-plan-setup/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: write-plan-setup
+description: >-
+  Scaffold an implementation-plan tree (implementation-plan.md,
+  status-and-next-steps.md, tasks/ skeletons) from ADRs, artifacts,
+  reflection-ready sources, or design docs. Same as Setup mode of retired
+  /transition-plan. Read ../SKILL.md first. Do NOT expand group detail here —
+  use write-plan-expand.
+disable-model-invocation: true
+---
+
+# Write-Plan Setup
+
+Before proceeding, **`read ../SKILL.md`** for family path rules, parity contract,
+and staged-directory guidance.
+
+---
+
+## When to use
+
+- After upstream decisions/design and the user wants a plan skeleton.
+- User says `/transition-plan` without expand, “scaffold implementation plan”,
+  or “setup planning tree”.
+- Needs `planning/…` or `planning-stageN/…` under a feature (see structure.yaml).
+
+## When not to use
+
+- No source material identified — refuse until ADR/design/artifact path exists.
+- User wants one group deeply specified — delegate to **write-plan-expand**.
+- `implementation-plan.md` already exists and user did not authorize new stage /
+  `--force` — stop and propose options.
+
+---
+
+## Input modes
+
+| Mode | Read |
+|------|------|
+| **from_adr** | ADR files under `decisions/…`; optional `research/…/requirements.md` |
+| **from_artifacts** | Provided artifact path (checklist, handoff, transition brief) |
+| **from_reflection** | Reflection doc; surface dependency if artifacts must generate first |
+| **from_design** | `design.md` or excerpts: goals, stages, scoped task groups |
+
+Extract: decisions, constraints, success criteria, and candidate group boundaries.
+
+---
+
+## Preconditions (stop if unmet)
+
+1. **Topic / feature name** known or inferable.
+2. **Input mode** chosen from the table above.
+3. Source paths exist — or stop with remediation options (`from_artifacts` paths,
+   reflection routing, staged dir choice).
+
+---
+
+## Setup workflow
+
+**Goal:** Create `implementation-plan.md`, `status-and-next-steps.md`, and
+scaffolding-only `tasks/NN-group-slug.md` files under the resolved planning root.
+
+1. **Load sources** using the declared input mode — extract grouping signals the way a human planner would summarize them (decisions, requirements, constraints, phased scope).
+2. **Choose transition type:** feature (default), release when path/content signals
+   a release rollout, ci-cd if pipeline-only.
+3. **Organize groups:** target 2–8 tasks per group; **global** numbering 1…N;
+   filenames `tasks/{NN}-{kebab-case}.md`.
+4. **Author `implementation-plan.md`** using **`../assets/implementation-plan.md`** as
+   boilerplate shape:
+   - YAML frontmatter: `task_count`, `groups[]` (`name`, `file`, integer `tasks`),
+     `tasks_files[]` aligned with groups order (`references/structure.yaml`).
+   - Body: checklist rows matching task_count exactly.
+5. **Author `status-and-next-steps.md`** from **`../assets/status-and-next-steps.md`** —
+   empty progress counts, next steps referencing expand.
+6. **Author group files:** duplicate **`../assets/task-group-skeleton.md`** once per group;
+   fill titles + 1-line hints **only**. Header **`Status:** 🔴 Scaffolding (needs expansion)**.
+   Keep the scaffolding warning banner referencing expand.
+7. **Commit suggestion:** bounded message such as `docs([feature]): create implementation plan scaffolding`;
+   list concrete `git add` paths.
+
+---
+
+## Behavioral contract
+
+- **Observable:** Every checkbox ties to exactly one eventual row inside a matching
+  group file; filenames match declared `tasks_files`.
+- **Bounded:** Cannot silently pick among multiple features — ask once if ambiguous.
+- **Outcome-framed:** Deliver skeleton files only — no Tier-2 TDD narratives yet.
+- **Delta-only:** Do not flood chat with pasted templates — **copy paths on disk**.
+- **Failure-aware:** Conflicting staged dirs, existing plan without policy, unreadable sources
+  → halt with branching options (`planning-stageN`, abort, waive).
+
+---
+
+## Gotchas
+
+1. **`tasks_files` parity:** Ordered duplicate of each `groups[i].file` — see `structure.yaml`.
+2. **`--all`-style expand is out of scope** here — deliberately skeleton-only outputs.
+3. **`from_reflection` may block** pending another generator — refuse silent filler.
+4. **Release layouts** reuse filenames; semantics differ inside group titles — still valid.
+5. **Staged dev-infra** often uses `planning-stage{N}/`; mirror sibling pattern already in use.
+
+---
+
+## Related
+
+- **write-plan-expand** — detail one group markdown.
+- **plan-review** — after several expands.
+- Canonical output map: **`../references/structure.yaml`** (`setup_output`).

--- a/templates/standard-project/.claude/skills/write-plan/write-plan-setup/SKILL.md
+++ b/templates/standard-project/.claude/skills/write-plan/write-plan-setup/SKILL.md
@@ -19,8 +19,7 @@ and staged-directory guidance.
 ## When to use
 
 - After upstream decisions/design and the user wants a plan skeleton.
-- User says `/transition-plan` without expand, “scaffold implementation plan”,
-  or “setup planning tree”.
+- User invokes **`write-plan-setup`**, **`/transition-plan`** (legacy alias) without expand, says “scaffold implementation plan”, or “setup planning tree”.
 - Needs `planning/…` or `planning-stageN/…` under a feature (see structure.yaml).
 
 ## When not to use
@@ -61,13 +60,12 @@ scaffolding-only `tasks/NN-group-slug.md` files under the resolved planning root
 
 1. **Load sources** using the declared input mode — extract grouping signals the way a human planner would summarize them (decisions, requirements, constraints, phased scope).
 2. **Choose transition type:** feature (default), release when path/content signals
-   a release rollout, ci-cd if pipeline-only.
+   a release rollout, **CI/CD** if pipeline-only.
 3. **Organize groups:** target 2–8 tasks per group; **global** numbering 1…N;
    filenames `tasks/{NN}-{kebab-case}.md`.
 4. **Author `implementation-plan.md`** using **`../assets/implementation-plan.md`** as
    boilerplate shape:
-   - YAML frontmatter: `task_count`, `groups[]` (`name`, `file`, integer `tasks`),
-     `tasks_files[]` aligned with groups order (`references/structure.yaml`).
+   - YAML frontmatter: `task_count`, `groups[]` (each `{ name, file, tasks }` where **`tasks`** is a **YAML list of integers** partitioning global checkbox IDs assigned to that group), `tasks_files[]` aligned with groups order (**`../references/structure.yaml`**).
    - Body: checklist rows matching task_count exactly.
 5. **Author `status-and-next-steps.md`** from **`../assets/status-and-next-steps.md`** —
    empty progress counts, next steps referencing expand.


### PR DESCRIPTION
## Summary

- Close out merged **PR #93** documentation on Stage 3 (Group 2 write-plan milestone) before Group 3 work.
- Expand **Skill Family Restructure** task scaffolding into executable specs (transition-plan semantics).
- Split **write-plan** in `templates/standard-project` into an **explore/research-style family**: thin parent hub, **`write-plan-setup`** (scaffold planning tree), **`write-plan-expand`** (deepen one group file); retain shared **`assets/`** and **`references/structure.yaml`**, extended with **`setup_output`** vs **`expand_output`**.
- Refactor **`decision`**: extract interview, hub README, and ADR scaffolds to **`assets/`**; add **`references/structure.yaml`**; slim **`SKILL.md`** to workflow + behavioral contract referencing those files.
- Update **explore** and **research** parent SKILL pipeline text to **`write-plan-setup`** (replacing **`/transition-plan`**).
- Mark Stage 3 Tasks **8–10** complete; record validation notes + progress (**10/15** tasks).

## Why

Group 3 of Stage 3 (Planner modernization) aligns the planner skills with the **family pattern** and completes the **`assets/` + `references/`** convention for **decision**, matching the decomposition direction already captured in Stage 3 planning (write-plan splits after the Group 2 single-file bridge). Consolidating scaffold text in **`assets/`** keeps SKILL bodies rubric-compliant and FR-8-portable while leaving YAML truth in **`structure.yaml`**.

## After Merge

- **Generated projects** from `standard-project` expose **three** Claude skills where one existed for planning: callers must invoke **`write-plan-setup`** or **`write-plan-expand`** explicitly (parent hub is informational only — same ergonomics as **explore** / **research** parents).
- **Decision** authoring now expects agents to **`cp`/`read` templated snippets from `skills/decision/assets/`** relative to skill root (`references/structure.yaml` documents filenames). Downstream forks that copied an older inlined **decision** SKILL should reconcile with the thinner parent + **`assets/`** layout on next sync.
- **Thinking-pipeline prose** updates (explore/research SKILL links) propagate to every new project scaffold; existing repos syncing template skill packs should pick these links up consciously.
- **CI note:** `./scripts/validate-templates.sh` on this branch reflects `develop`'s expectation for `.cursor/rules/main.mdc` (missing on `develop`; validation reported error locally unrelated to skill edits).

## Follow-ups

- **Group 4 — plan-review**: audit + SKILL conversion referencing the family + **`structure.yaml`** pattern established here.
- **Cutover**: archive legacy `.cursor/commands/transition-plan.md` (Stage 5) after plan-review completes — not attempted in this PR.
- Optional tightening of **`write-plan`** `schema_version`/duplicate `outputs` block in **`structure.yaml`** if downstream tooling prefers a single output section.
