### PR TITLE
feat(agentic-workflow-modernization): Plan-Review Skill (Group 4)

### DIFF
--- a/admin/feedback/sourcery/pr95.md
+++ b/admin/feedback/sourcery/pr95.md
@@ -1,0 +1,60 @@
+# Sourcery Review Analysis
+**PR**: #95
+**Repository**: grimm00/dev-infra
+**Generated**: Sat May  2 22:22:39 CDT 2026
+
+---
+
+## Summary
+
+Total Individual Comments: 0 + Overall Comments
+
+## Individual Comments
+
+## Overall Comments
+
+- The path resolution rules for `planning/` vs `planning-stage{N}/` are described in detail in both `SKILL.md` and `references/structure.yaml`; consider trimming the SKILL prose to a higher-level description and pointing explicitly at the YAML to reduce future drift between the two sources.
+- In `references/structure.yaml`, the `prior_stage_carry_forward.suggested_reads` entries introduce `path_optional_glob` alongside `path_glob`; it may be simpler for consumers if all entries share a consistent key shape (e.g., a single `glob` plus an `optional: true` flag) to avoid special-case handling.
+
+## Priority Matrix Assessment
+
+Use this template to assess each comment:
+
+| Comment | Priority | Impact | Effort | Action |
+|---------|----------|--------|--------|--------|
+| Overall — SKILL vs YAML duplication risk | MEDIUM | MEDIUM | LOW | Trimmed Path resolution prose; delegated authoritative globs to `references/structure.yaml`. |
+| Overall — inconsistent keys under `suggested_reads` | MEDIUM | MEDIUM | LOW | Normalized to `glob` + `optional` boolean on each row in `structure.yaml`. |
+
+### Overall reviewer notes (resolution)
+
+| Note | Action |
+|------|--------|
+| Path prose duplication | SKILL carries summary table only; **`planning_roots`** remains canonical in YAML. |
+| suggested_reads shape | Unified **`glob`** / **`optional`** fields for tooling symmetry. |
+
+---
+
+## Resolution (branch updates)
+
+- Normalized **`prior_stage_carry_forward.suggested_reads`** keys (`glob` + `optional`).
+- Shortened **`plan-review/SKILL.md`** Path resolution section with explicit YAML pointer.
+
+### Priority Levels
+- 🔴 **CRITICAL**: Security, stability, or core functionality issues
+- 🟠 **HIGH**: Bug risks or significant maintainability issues
+- 🟡 **MEDIUM**: Code quality and maintainability improvements
+- 🟢 **LOW**: Nice-to-have improvements
+
+### Impact Levels
+- 🔴 **CRITICAL**: Affects core functionality
+- 🟠 **HIGH**: User-facing or significant changes
+- 🟡 **MEDIUM**: Developer experience improvements
+- 🟢 **LOW**: Minor improvements
+
+### Effort Levels
+- 🟢 **LOW**: Simple, quick changes
+- 🟡 **MEDIUM**: Moderate complexity
+- 🟠 **HIGH**: Complex refactoring
+- 🔴 **VERY_HIGH**: Major rewrites
+
+

--- a/admin/planning/opportunities/internal/dev-infra/learnings/README.md
+++ b/admin/planning/opportunities/internal/dev-infra/learnings/README.md
@@ -28,7 +28,8 @@
 
 ### Learning Documents
 
-- **[Decision Interview Exercise](decision-interview-exercise-learnings.md)** - First real use of the decision interview pattern: what worked, what to improve, unexpected discoveries ⭐ **NEW**
+- **[Agentic Workflow Stage 3 — Pipeline Synthesis Gap](agentic-workflow-stage3-pipeline-synthesis-gap.md)** - Missing synthesis step in group-cycle pipeline; narrative/int-opp/reflection triggers; plan-review input reliability ⭐ **NEW**
+- **[Decision Interview Exercise](decision-interview-exercise-learnings.md)** - First real use of the decision interview pattern: what worked, what to improve, unexpected discoveries
 - **[Requirements and Design Prior Art](requirements-and-design-prior-art.md)** - Team engineering proposal that informed the design step discovery in agentic-workflow-modernization
 - **[Fix Management Workflow Learnings](fix-management-workflow-learnings.md)** - Learnings from completing all 8 cross-PR fix batches (28 issues)
 - **[Command Adaptation Template Learnings](command-adaptation-template-learnings.md)** - Learnings from creating the Command Adaptation Template feature
@@ -53,17 +54,18 @@ This directory contains learnings from dev-infra development that can inform:
 
 ## 📊 Summary
 
-**Total Learning Documents:** 25  
+**Total Learning Documents:** 26  
 **Feature-Specific Learnings:** 9 features (22 phases + 5 fix batches + 1 release total)  
 **CI/CD Improvement Learnings:** 2 improvements  
 **Status:** ✅ Active
 
 **Recent Additions:**
-- **Decision Interview Exercise (2026-04-14)** - First use of the interview pattern for agentic-workflow-modernization ⭐ **NEW**
+- **Pipeline Synthesis Gap (2026-05-02)** - Missing synthesis step in group-cycle; learnings feed-forward for plan-review ⭐ **NEW**
+- **Decision Interview Exercise (2026-04-14)** - First use of the interview pattern for agentic-workflow-modernization
 - Requirements and Design Prior Art (2026-04-02) - Team proposal that informed design step discovery
 - Template Doc Infrastructure Learnings (2026-01-16) - Phase 1 Template Creation: ADR-driven structure, placeholder conventions
 - Explore Two-Mode Learnings (2026-01-13) - Phase 1 Command Structure: task-based docs, timing guidance
 
 ---
 
-**Last Updated:** 2026-04-14
+**Last Updated:** 2026-05-02

--- a/admin/planning/opportunities/internal/dev-infra/learnings/agentic-workflow-stage3-pipeline-synthesis-gap.md
+++ b/admin/planning/opportunities/internal/dev-infra/learnings/agentic-workflow-stage3-pipeline-synthesis-gap.md
@@ -1,0 +1,84 @@
+# Dev-Infra Learnings — Agentic Workflow Stage 3: Pipeline Synthesis Gap
+
+**Project:** Dev-Infra
+**Topic:** Missing synthesis step in the group-cycle pipeline
+**Date:** 2026-05-02
+**Last Updated:** 2026-05-02
+
+---
+
+## 📋 Overview
+
+During Stage 3 of the agentic-workflow-modernization feature, we identified that the group-cycle agent pipeline has no step for capturing learnings that arise during implementation. Narratives, int-opps, and reflections are all human-initiated commands with no automatic trigger — meaning mid-implementation discoveries (like adding the `assets/` + `references/` convention, or recognizing that `write-plan` needed family decomposition) live only in conversation context and evaporate between sessions. This became visible when plan-review had nothing structured to check for "prior-learnings carry-forward."
+
+---
+
+## ✅ What Worked Well
+
+### Group-cycle agent mechanical ceremony
+
+**Why it worked:** The `post-pr` → `pre-phase-review` → expand → execute → PR → validate → report pipeline reliably handles bookkeeping: checkboxes, status docs, Sourcery review, PR descriptions. These mechanical steps never get forgotten because they're encoded in the agent definition.
+**Template implications:** The ceremony-as-code pattern is sound. The gap is not in the mechanical steps but in the absence of a synthesis step.
+
+### In-chat course corrections
+
+**Why it worked:** When we realized write-plan needed family decomposition (overriding the subagent's single-skill decision) and that decision needed `assets/` extraction, we caught it in real-time discussion and inserted Group 3. The `/discuss` skill enabled thinking-without-committing before modifying the plan.
+**Template implications:** The `/discuss` → plan modification loop works. The problem is that the *reasoning* behind the modification isn't captured anywhere persistent — it lived in a chat session.
+
+---
+
+## 🟡 What Needs Improvement
+
+### No synthesis step in group-cycle pipeline
+
+**What the problem was:** The pipeline goes from task execution (Step 2) directly to PR creation (Step 3). There is no "what did we learn?" step. Step 6 (Report) produces a chat summary, not a persisted artifact. Learnings from implementation — scope additions, pattern discoveries, decomposition overrides — aren't captured in a format that plan-review or future stages can consume.
+**How to prevent:** Add a "Step 2.5: Capture learnings" or fold synthesis into Step 6 as a committed artifact (not just a chat message). This artifact would be a lightweight structured document — not a full narrative, but enough for plan-review to verify carry-forward.
+**Template changes needed:** Update `group-cycle.agent.md` pipeline definition. Consider whether the synthesis artifact lives in `planning-stageN/artifacts/` or alongside the Sourcery review in `admin/feedback/`.
+
+### Narrative / int-opp / reflection have no pipeline trigger
+
+**What the problem was:** All three are human-initiated commands. Narrative is stage-scoped ("after a feature or significant piece of work"), int-opp is learning-scoped ("capture what worked"), and reflection is personal ("daily progress and growth"). None of them are triggered by the pipeline, so they only happen when someone remembers to run them.
+**How to prevent:** Define cadence expectations: narrative after stage completion, int-opp after significant course corrections, reflection at session end. Consider encoding at least the narrative trigger into the stage-transition workflow (when `write-plan --setup` is run for a new stage, prompt for a prior-stage narrative).
+**Template changes needed:** When these commands are converted to skills (Stage 4), their `## When to Use` sections should include pipeline integration points, not just manual invocation patterns.
+
+### int-opp is outward-facing; no inward-facing equivalent
+
+**What the problem was:** `int-opp` captures "learnings from project work to improve dev-infra templates and future projects" — it's aimed at other projects. The most valuable learnings during Stage 3 were ones that fed back into *this project's* next cycle: assets convention, family decomposition override, plan-review restoration. These aren't "opportunities for other projects"; they're "things the next group needs to know."
+**How to prevent:** Distinguish between outward-facing learnings (int-opp: "here's what other projects should do") and inward-facing carry-forward (pipeline synthesis: "here's what the next cycle needs to account for"). Plan-review's `structure.yaml` should declare which artifact types it expects as inputs.
+**Template changes needed:** plan-review's `references/structure.yaml` should declare expected prior-cycle artifacts. The synthesis step should produce artifacts that match that schema.
+
+---
+
+## 💡 Unexpected Discoveries
+
+### Plan-review's value depends on upstream artifact reliability
+
+**Finding:** We initially deferred plan-review from Stage 3, then restored it after realizing it was the only skill that enforces cross-stage learning carry-forward. But even with plan-review converted, it can only verify what exists. If the synthesis artifacts don't exist because nothing triggered their creation, plan-review reviews an empty shelf.
+**How to leverage:** Design plan-review's skill contract to *flag* missing artifacts (not just check existing ones). If a prior stage has no narrative, no learnings doc, no course-correction notes, plan-review should warn — not silently pass.
+
+### Chat-context learnings are the highest-value, most-perishable artifacts
+
+**Finding:** The most impactful decisions during Stage 3 (overriding write-plan decomposition, restoring plan-review, inserting Group 3, adding assets/references convention) all happened in `/discuss` sessions. These decisions shaped the entire stage but existed only in ephemeral conversation context. Without the human remembering to formalize them, they'd be invisible to future stages.
+**How to leverage:** The `/discuss --summary` output format is close to what's needed — it captures key points, questions, and suggested actions. If summaries were optionally persisted (user-triggered, not automatic), they could serve as lightweight synthesis artifacts.
+
+---
+
+## ⏱️ Time Investment
+
+| Activity | Time | Notes |
+|----------|------|-------|
+| Identifying the gap | ~10 min | Emerged naturally during `/discuss` about plan-review's input requirements |
+| Tracing root cause | ~5 min | Quick once we looked at the group-cycle pipeline steps and noticed the absence |
+| Scoping the three sub-problems | ~10 min | Distinguishing trigger, overlap, and feed-forward took most of the thinking |
+
+---
+
+## 📝 Additional Notes
+
+- This learning is directly relevant to Stage 4 (Executor role group), where `narrative`, `int-opp`, and `reflect` will be converted to skills. The pipeline integration question should be resolved *during* their conversion, not deferred.
+- The `assets/` miss in the research family (which prompted this entire discussion) is the canonical example: a mid-implementation discovery that changed the convention for all Stage 3 skills, caught only because the human noticed it in chat.
+- Consider whether `group-cycle.agent.md` Step 6 (Report) should commit a `group-N-learnings.md` artifact alongside the Sourcery review file. This would be the lightest-weight intervention — no new skills or triggers, just an addition to the existing pipeline.
+
+---
+
+**Last Updated:** 2026-05-02

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/artifacts/plan-review-command-audit.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/artifacts/plan-review-command-audit.md
@@ -1,0 +1,93 @@
+# Audit: `plan-review` command → skill conversion
+
+**Source:** `.cursor/commands/plan-review.md` (416 lines)  
+**Feature:** agentic-workflow-modernization / Stage 3 Group 4  
+**Date:** 2026-05-03  
+**Tier definitions:** ADR-004 — Tier 1 precise, Tier 2 mixed (rewrite for five-property rubric), Tier 3 vague/problematic (rewrite or remove).
+
+---
+
+## Executive summary
+
+| Finding | Detail |
+|---------|--------|
+| Single-mode procedural skill | Seven numbered steps (load plan → review groups → deps → consistency → issues → report → summary). No alternate modes unlike transition-plan; **one SKILL.md** (+ `assets/` + `references/structure.yaml`) is sufficient. |
+| **Staged planning gap** | Path detection lists only `…/planning/` (dev-infra) and maintainer `docs/…/features/[feature]/`. It omits **`planning-stage{N}/`** siblings used throughout agentic-workflow modernization and declared on **`write-plan`** (`references/structure.yaml`). Skill **must** resolve the active stage directory the same way as write-plan. |
+| Prior learnings carry-forward gap | Command validates dependencies and consistency **within** the current tree only. It never instructs comparing **prior stage** narratives (`planning-stage{N-1}/status-and-next-steps.md`, milestones, spike notes). Skill adds an explicit **review dimension** + YAML declaration. |
+| Report template bulk | Step 6 embeds ~80 lines of markdown template → **Tier 2 delta-only risk** if pasted into SKILL.md. Move verbatim skeleton to **`assets/review-checklist.md`**; SKILL references filenames only (FR-8 friendly). |
+| Legacy pointers | Footer still references **`/pre-phase-review`** as deprecated; SKILL should cite **`docs/MIGRATION-v0.10.md`** once and steer uniform-structure readers here only. |
+
+---
+
+## Workflow mapping (command steps → skill)
+
+| Command step | Topic | Skill placement |
+|--------------|-------|-----------------|
+| §1 Load & parse implementation plan | Frontmatter parity, checkbox census, optional `--group N` narrowing | Workflow §1 |
+| §2 Review task group files | Structure, sizing warnings, numbering | Workflow §2 |
+| §3 Validate dependencies | Intra-/cross-group + externals | Workflow §3 |
+| §4 Check consistency | Plan ↔ status ↔ task bodies ↔ frontmatter | Workflow §4 |
+| §5 Identify issues | Blockers / warnings / recommendations | Workflow §5 |
+| §6 Generate review report | Path under planning root + template | Workflow §6 + **`assets/review-checklist.md`** |
+| §7 Present summary | Chat footer block | Workflow §7 |
+
+---
+
+## Section-by-section classification
+
+| Location / topic | Tier | Rationale | Skill action |
+|------------------|------|-----------|--------------|
+| Title + overview | 1 | Clear triggers | Keep |
+| Plan path detection — dev-infra `planning/` only | **2→fix** | Missing `planning-stage{N}/` breaks Stage 3 meta-planning | **Extend** rows to mirror write-plan parent |
+| Plan path — template project | 1 | Stable | Keep |
+| Feature detection (“prompt if multiple”) | 2 | Needs bounded stop/list behavior | Prefer explicit `--feature`; else enumerate candidates and STOP |
+| Legacy fallback (`feature-plan.md` / `phase-*`) | 1 | Points to migration | Keep short pointer |
+| Step 1 frontmatter rules | 1 | Mechanical checks | Keep; duplicate summary in **`references/structure.yaml`** |
+| Steps 2–5 checklists | 1 | Observable checks | Keep condensed |
+| Step 6 report template fence | 2 | Long | **Move** to `assets/` |
+| `--dry-run` | 1 | Display-only path | Keep explicit branch |
+| Tips / related commands | 2 | References `/transition-plan`, `/task` | Map to **`write-plan-*`** + task workflows |
+
+---
+
+## Consolidated tier tallies
+
+| Tier | Approx. blocks | Notes |
+|------|----------------|-------|
+| Tier 1 | 22 | Path tables (extended), YAML rules, checklist bullets, severity taxonomy |
+| Tier 2 | 8 | Feature auto-detect, oversize-group heuristics, related-command prose |
+| Tier 3 | 0 | None identified after removing merge-to-develop assumptions |
+
+---
+
+## `assets/` / `references/` inventory
+
+| Artifact | Target path | Role |
+|----------|-------------|------|
+| Review report skeleton + section prompts | `assets/review-checklist.md` | Copy/adapt into dated `plan-review-YYYY-MM-DD.md` |
+| Declared inputs, dimensions, outputs | `references/structure.yaml` | Parity with decision/write-plan declarative contracts |
+
+---
+
+## Five-property check (command-wide)
+
+| Property | Pass? | Gap |
+|----------|-------|-----|
+| Observable | Mostly | Issue taxonomy clear; staged-root choice must be explicit |
+| Bounded | Mostly | `--group` scopes well; multi-feature detection needs STOP semantics |
+| Outcome-framed | Yes | Report path + readiness labels |
+| Delta-only | **Fail** raw | Large template fence → **fix** via `assets/review-checklist.md` |
+| Failure-aware | Partial | Weak on missing prior-stage artifacts when carry-forward claimed |
+
+---
+
+## Skill design decisions (from audit)
+
+1. **Path parity:** Duplicate the write-plan **`planning/` vs `planning-stage{N}/`** detection table (short form) + cite canonical YAML glob notes.
+2. **Prior-stage carry-forward:** Add Workflow §4b (after consistency) requiring explicit scan of **prior** stage status/narratives when `planning-stage{N}/` with `N>1`.
+3. **FR-8:** SKILL holds behavioral contract + numbered workflow; checklist prose lives in **`assets/`**; machine-readable dimensions live in **`references/structure.yaml`**.
+4. **Invocation:** Align YAML `disable-model-invocation` with sibling planner skills (**true**) — routed via tooling/description like write-plan-expand.
+
+---
+
+**Last Updated:** 2026-05-03

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/implementation-plan.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/implementation-plan.md
@@ -82,7 +82,7 @@ Convert the **Planner** role group of dev-infra commands to skills. This stage c
 - [x] Task 10: Validate restructured skills (rubric + structure.yaml accuracy)
 
 ### Plan-Review Skill
-- [ ] Task 11: Audit plan-review command and classify behavioral instructions
+- [x] Task 11: Audit plan-review command and classify behavioral instructions
 - [ ] Task 12: Convert plan-review to SKILL.md
 
 ### Cutover and Quality Gate

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/implementation-plan.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/implementation-plan.md
@@ -83,7 +83,7 @@ Convert the **Planner** role group of dev-infra commands to skills. This stage c
 
 ### Plan-Review Skill
 - [x] Task 11: Audit plan-review command and classify behavioral instructions
-- [ ] Task 12: Convert plan-review to SKILL.md
+- [x] Task 12: Convert plan-review to SKILL.md
 
 ### Cutover and Quality Gate
 - [ ] Task 13: Install skills + archive commands (decision, write-plan, plan-review)
@@ -97,7 +97,7 @@ Convert the **Planner** role group of dev-infra commands to skills. This stage c
 - [x] decision skill exists with interview workflow and ADR behavioral contract
 - [x] write-plan is a family: parent + write-plan-setup + write-plan-expand
 - [x] decision has `assets/` + `references/structure.yaml`
-- [ ] plan-review skill exists with staged-planning path support
+- [x] plan-review skill exists with staged-planning path support
 - [ ] All skills pass five-property rubric with populated gotchas
 - [ ] Self-containment (FR-8) verified for each skill
 - [ ] All Stage 3 skills have `assets/` (where applicable) + `references/structure.yaml`

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/implementation-plan.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/implementation-plan.md
@@ -27,10 +27,11 @@ tasks_files:
 
 **Status:** 🟠 In Progress
 **Created:** 2026-05-02
-**Last Updated:** 2026-05-02
+**Last Updated:** 2026-05-03
 **Source:** [ADRs 1-5 + design.md Section 5](../decisions/) → Stage 3 of 4-stage v1  
 **Group 1 merged:** PR #92 (2026-05-03)  
-**Group 2 merged:** PR #93 (2026-05-03)
+**Group 2 merged:** PR #93 (2026-05-03)  
+**Group 3 merged:** PR #94 (2026-05-03)
 
 ---
 
@@ -45,7 +46,7 @@ Convert the **Planner** role group of dev-infra commands to skills. This stage c
 
 **Key Changes:**
 
-- decision: hybrid skill — procedural interview workflow + behavioral contract for ADR quality. Bakes in the interview pattern from this feature's own research. Follow-up: extract inline templates into `assets/` + add `references/structure.yaml` (Group 3).
+- decision: hybrid skill — procedural interview workflow + behavioral contract for ADR quality. **Group 3** extracted templates into `assets/` + `references/structure.yaml`.
 - transition-plan → write-plan: family pattern (parent hub + write-plan-setup + write-plan-expand). Initial single-skill conversion (Group 2) restructured into family (Group 3). **First skill to adopt `assets/` + `references/` convention** (most template-heavy).
 - plan-review: procedural review skill — ensures stage plans account for prior learnings and cross-checks consistency. Adopts the `assets/` + `references/` convention.
 - 3 commands archived after conversion (decision, transition-plan, plan-review).
@@ -117,4 +118,4 @@ Convert the **Planner** role group of dev-infra commands to skills. This stage c
 
 ---
 
-**Last Updated:** 2026-05-02
+**Last Updated:** 2026-05-03

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/status-and-next-steps.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/status-and-next-steps.md
@@ -7,21 +7,21 @@
 
 ## 📊 Progress Summary
 
-**Overall:** 10/15 tasks complete
+**Overall:** 12/15 tasks complete
 
 | Group | Status | Progress | Notes |
 |-------|--------|----------|-------|
 | Decision Skill | ✅ Active/Complete | 3/3 tasks | Merged PR #92; audit, `decision/SKILL.md`, validation GO |
 | Write-Plan Skill | ✅ Active/Complete | 4/4 tasks | Merged [PR #93](https://github.com/grimm00/dev-infra/pull/93): audit, single-skill `write-plan/` + assets + structure.yaml, meta-test GO |
 | Skill Family Restructure | ✅ Active/Complete | 3/3 tasks | Merged [PR #94](https://github.com/grimm00/dev-infra/pull/94): write-plan family + decision assets/`references/` |
-| Plan-Review Skill | 🔴 Not Started | 0/2 tasks | Audit, convert (staged-planning path support) |
+| Plan-Review Skill | ✅ Active/Complete | 2/2 tasks | Audit artifact + template `plan-review/` skill (staged roots + carry-forward) |
 | Cutover and Quality Gate | 🔴 Not Started | 0/3 tasks | Install, rubric sweep, exit criteria |
 
 ---
 
 ## 🚀 Next Steps
 
-1. **Group 4** — Plan-Review skill audit and SKILL conversion (staged planning paths).
+1. **Group 5** — Cutover: archive planner commands; full Stage 3 rubric gate.
 
 ---
 

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/status-and-next-steps.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/status-and-next-steps.md
@@ -1,7 +1,7 @@
 # Status & Next Steps — Stage 3: Planner
 
 **Status:** 🟠 In Progress
-**Last Updated:** 2026-05-02
+**Last Updated:** 2026-05-03
 
 ---
 
@@ -13,7 +13,7 @@
 |-------|--------|----------|-------|
 | Decision Skill | ✅ Active/Complete | 3/3 tasks | Merged PR #92; audit, `decision/SKILL.md`, validation GO |
 | Write-Plan Skill | ✅ Active/Complete | 4/4 tasks | Merged [PR #93](https://github.com/grimm00/dev-infra/pull/93): audit, single-skill `write-plan/` + assets + structure.yaml, meta-test GO |
-| Skill Family Restructure | ✅ Active/Complete | 3/3 tasks | Parent + setup/expand; decision `assets/` + `references/`; validated in-task |
+| Skill Family Restructure | ✅ Active/Complete | 3/3 tasks | Merged [PR #94](https://github.com/grimm00/dev-infra/pull/94): write-plan family + decision assets/`references/` |
 | Plan-Review Skill | 🔴 Not Started | 0/2 tasks | Audit, convert (staged-planning path support) |
 | Cutover and Quality Gate | 🔴 Not Started | 0/3 tasks | Install, rubric sweep, exit criteria |
 
@@ -40,4 +40,4 @@
 
 - **Group 1 — Decision skill** — merged via [PR #92](https://github.com/grimm00/dev-infra/pull/92) (2026-05-03)
 - **Group 2 — Write-Plan skill** — merged via [PR #93](https://github.com/grimm00/dev-infra/pull/93) (2026-05-03)
-- **Group 3 — Skill family restructure** — [PR #94](https://github.com/grimm00/dev-infra/pull/94)
+- **Group 3 — Skill family restructure** — merged via [PR #94](https://github.com/grimm00/dev-infra/pull/94) (2026-05-03)

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/status-and-next-steps.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/status-and-next-steps.md
@@ -41,3 +41,4 @@
 - **Group 1 — Decision skill** — merged via [PR #92](https://github.com/grimm00/dev-infra/pull/92) (2026-05-03)
 - **Group 2 — Write-Plan skill** — merged via [PR #93](https://github.com/grimm00/dev-infra/pull/93) (2026-05-03)
 - **Group 3 — Skill family restructure** — merged via [PR #94](https://github.com/grimm00/dev-infra/pull/94) (2026-05-03)
+- **Group 4 — Plan-review skill** — opened [PR #95](https://github.com/grimm00/dev-infra/pull/95)

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/tasks/04-plan-review-skill.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/tasks/04-plan-review-skill.md
@@ -2,7 +2,7 @@
 
 **Feature:** Agentic Workflow Modernization (Stage 3: Planner)
 **Group:** Plan-Review Skill
-**Status:** 🟠 In Progress
+**Status:** ✅ Active/Complete
 **Last Updated:** 2026-05-03
 
 ---
@@ -16,7 +16,7 @@
   - Key gap to address: path detection doesn't support `planning-stageN/` directories
   - **Identify checklist/reference content** that belongs in `assets/` or `references/`
 
-- [ ] Task 12: Convert plan-review to SKILL.md
+- [x] Task 12: Convert plan-review to SKILL.md
   - **Skill directory structure:**
     ```
     skills/plan-review/
@@ -45,11 +45,11 @@
 
 ## ✅ Completion Criteria
 
-- [ ] Audit artifact with tier classification
-- [ ] plan-review SKILL.md in templates with rubric pass and gotchas
-- [ ] Staged planning path support (`planning-stageN/`)
-- [ ] `references/structure.yaml` with input/output schema
-- [ ] Self-containment (FR-8) verified
+- [x] Audit artifact with tier classification
+- [x] plan-review SKILL.md in templates with rubric pass and gotchas
+- [x] Staged planning path support (`planning-stageN/`)
+- [x] `references/structure.yaml` with input/output schema
+- [x] Self-containment (FR-8) verified
 
 ---
 
@@ -61,4 +61,4 @@
 
 ---
 
-**Last Updated:** 2026-05-02
+**Last Updated:** 2026-05-03

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/tasks/04-plan-review-skill.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage3/tasks/04-plan-review-skill.md
@@ -2,16 +2,14 @@
 
 **Feature:** Agentic Workflow Modernization (Stage 3: Planner)
 **Group:** Plan-Review Skill
-**Status:** 🔴 Scaffolding (needs expansion)
-**Last Updated:** 2026-05-02
+**Status:** 🟠 In Progress
+**Last Updated:** 2026-05-03
 
 ---
 
 ## 📝 Tasks
 
-> ⚠️ **Scaffolding:** Run `/write-plan agentic-workflow-modernization --expand --group 4` to add detailed implementation notes.
-
-- [ ] Task 11: Audit plan-review command and classify behavioral instructions
+- [x] Task 11: Audit plan-review command and classify behavioral instructions
   - Read `.cursor/commands/plan-review.md` (416 lines)
   - Classify instructions against precision tiers
   - Produce audit artifact at `planning-stage3/artifacts/plan-review-command-audit.md`

--- a/templates/standard-project/.claude/skills/plan-review/SKILL.md
+++ b/templates/standard-project/.claude/skills/plan-review/SKILL.md
@@ -36,16 +36,14 @@ review artifact named in **`references/structure.yaml`** (`report_output`).
 
 ## Path resolution
 
-Pick **exactly one** planning root for the invocation — identical semantics to **`write-plan`** parent:
+Mirror **`write-plan`** parent semantics: choose **one** subtree where `implementation-plan.md` + `tasks/` live (dev-infra row **or** maintainer-docs row).
 
-| Layout | Planning root |
-|--------|----------------|
-| Dev-infra feature | `admin/services/[service]/features/[feature]/` + **`planning/`** OR **`planning-stage{N}/`** |
+| Layout | Planning root (summary) |
+|--------|-------------------------|
+| Dev-infra feature | `admin/services/[service]/features/[feature]/` + `planning/` **or** `planning-stage{N}/` |
 | Template maintainer | `docs/maintainers/planning/features/[feature]/` |
 
-**Staged planning:** Prefer the newest intentional stage directory actually holding the active `implementation-plan.md`. When multiple staged dirs exist, **STOP** if ambiguity remains after `--feature` disambiguation — list candidates and ask for explicit subdirectory choice.
-
-Canonical glob notes: **`references/structure.yaml`** (`planning_roots`).
+If several `planning-stage*` dirs exist, **STOP** after listing candidates unless the operator names the exact subdirectory. **Authoritative** glob text + notes: **`references/structure.yaml`** → `planning_roots`.
 
 ---
 

--- a/templates/standard-project/.claude/skills/plan-review/SKILL.md
+++ b/templates/standard-project/.claude/skills/plan-review/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: plan-review
+description: >-
+  Validate implementation-plan scaffolding before execution: YAML parity,
+  task-group quality, dependency ordering, cross-document consistency, and
+  prior-stage learning carry-forward for planning-stageN layouts. Mirrors the
+  retired /plan-review command. Read references/structure.yaml for dimensions.
+disable-model-invocation: true
+---
+
+# Plan Review
+
+Ensure **uniform planning trees** are internally consistent before `/task` style
+execution. Replaces `.cursor/commands/plan-review.md` with the same behavioral
+contract plus **`planning-stage{N}/`** parity with **`write-plan`**.
+
+Heavy checklist prose lives in **`assets/review-checklist.md`** — copy into the dated
+review artifact named in **`references/structure.yaml`** (`report_output`).
+
+---
+
+## When to use
+
+- Immediately **before** starting work on a new task group when scaffolding exists.
+- After **`write-plan-setup`** / **`write-plan-expand`** produced or mutated files.
+- User invokes `/plan-review`, names this skill, or supplies `--check-deps` /
+  `--check-tests` emphasis flags.
+
+## When not to use
+
+- Planning tree absent → run **`write-plan-setup`** first.
+- Legacy-only phase markdown (`phase-*.md` without uniform frontmatter) → migrate per
+  **`docs/MIGRATION-v0.10.md`** instead of forcing this checklist.
+
+---
+
+## Path resolution
+
+Pick **exactly one** planning root for the invocation — identical semantics to **`write-plan`** parent:
+
+| Layout | Planning root |
+|--------|----------------|
+| Dev-infra feature | `admin/services/[service]/features/[feature]/` + **`planning/`** OR **`planning-stage{N}/`** |
+| Template maintainer | `docs/maintainers/planning/features/[feature]/` |
+
+**Staged planning:** Prefer the newest intentional stage directory actually holding the active `implementation-plan.md`. When multiple staged dirs exist, **STOP** if ambiguity remains after `--feature` disambiguation — list candidates and ask for explicit subdirectory choice.
+
+Canonical glob notes: **`references/structure.yaml`** (`planning_roots`).
+
+---
+
+## Preconditions
+
+1. **`implementation-plan.md`** readable at chosen root.
+2. **`tasks/`** directory exists (may be scaffolding).
+3. Feature scope explicit (`--feature`) **when** multiple planning trees match repo detection.
+
+---
+
+## Behavioral contract (five-property rubric)
+
+| Property | Obligation |
+|----------|------------|
+| Observable | Enumerate blockers vs warnings vs recommendations with file paths + task IDs; readiness label MUST match blocker presence. |
+| Bounded | Respect `--group N` narrow scope; otherwise review full frontmatter union — STOP after producing report OR dry-run summary. |
+| Outcome-framed | Deliver dated **`plan-review-YYYY-MM-DD.md`** (unless `--dry-run`) filled from **`assets/review-checklist.md`** scaffolding. |
+| Delta-only | Do not paste entire planning documents into chat — cite paths + deltas vs expectations from **`references/structure.yaml`**. |
+| Failure-aware | Missing files, ambiguous staged roots, or frontmatter/task mismatches escalate as **blockers** with remediation hints — never silently OK. |
+
+---
+
+## Workflow
+
+### 1. Load implementation plan
+
+1. Resolve planning root (§ Path resolution).
+2. Validate YAML frontmatter using **`references/structure.yaml`** (`implementation_plan_frontmatter` + parity rules aligned with **`write-plan`**).
+3. Verify global task IDs `1…task_count` appear exactly once across `groups[].tasks`.
+4. Confirm every `tasks_files[]` entry exists relative to planning root.
+
+### 2. Review task group files
+
+For each group (or **only group `N`** when scoped):
+
+1. Validate markdown scaffolding sections (`Tasks`, `Dependencies`, goals/stats headers).
+2. Compare embedded task numbers against owning `groups[].tasks`.
+3. Emit sizing warnings when a group owns **below two** or **above eight** tasks (warnings only unless specs contradict frontmatter).
+
+### 3. Validate dependencies
+
+Trace intra-group ordering, cross-group references, and prerequisite completeness — dimensions `dependencies` + `prior_learnings` in **`references/structure.yaml`**.
+
+### 4. Consistency sweep
+
+Cross-check:
+
+1. Checkbox totals vs **`status-and-next-steps.md`** narrative counts.
+2. Task titles vs inline checkbox lines inside group markdown.
+3. Phantom tasks / orphaned headings vs YAML inventory.
+
+### 5. Prior-stage learning carry-forward
+
+When active root matches **`planning-stage{N}/`** with **`N > 1`**:
+
+1. Locate **`planning-stage{N-1}/`** sibling directory.
+2. Read prior **`status-and-next-steps.md`** + **`implementation-plan.md`** surfaces hinted by YAML `prior_stage_carry_forward`.
+3. Record explicit gaps: unresolved deferrals, spike follow-ups, PR-linked narratives **missing** from current stage plan → warnings minimum; unresolved contradictions → blockers.
+
+Skip this subsection entirely when no numeric predecessor exists **or** repository uses flat **`planning/`** without staged dirs.
+
+### 6. Issue taxonomy & evidence bucket
+
+Classify findings:
+
+| Severity | Meaning |
+|----------|---------|
+| Blocker | Structural inconsistency preventing faithful execution |
+| Warning | Risk / clarity gap — execution tolerable after acknowledgment |
+| Recommendation | Optional improvement |
+
+### 7. Produce review artifact
+
+1. Instantiate **`assets/review-checklist.md`** at planning root → rename pattern **`plan-review-YYYY-MM-DD.md`** (`report_output` in YAML).
+2. **`--dry-run`:** Stream identical Markdown sections into assistant reply instead of writing disk file — still include readiness verdict.
+3. Finish with concise CLI-style footer listing blocker/warning counts + saved relative path.
+
+---
+
+## Gotchas
+
+- **Staged ambiguity:** Multiple `planning-stage*` dirs without explicit operator choice yields **false confidence** — always confirm directory first.
+- **Checkbox drift:** Editors sometimes mutate markdown lists without syncing YAML — treat mismatch as **blocker**, not cosmetic.
+- **`task_count` lying:** Never bump YAML without recounting union of group-owned IDs across ALL files.
+- **Dry-run ≠ silent OK:** Operators still need categorical counts even when skipping filesystem writes.
+- **Prior-stage nostalgia:** Completed milestones prose often hides dependency baggage — skim Notes before endorsing ✅ readiness.
+- **Template-only repos:** Maintainer layout lacks `planning-stage*` pattern — skip staged carry-forward quietly after recording rationale in report header.
+
+---
+
+## Related
+
+- **`write-plan`** family — upstream scaffolding producer (`write-plan-setup`, `write-plan-expand`).
+- **`decision`** — precedes planning when ADRs justify transition planning.
+- Legacy commands remain readable until archival PR completes Stage 3 cutover group.
+
+---
+
+## FR-8 (self-containment)
+
+Core workflow above is executable **without** loading `.cursor/commands/plan-review.md`. Companion **`assets/`** + **`references/`** files provide templates and declarative parity checks — optional depth, not hidden prerequisites.

--- a/templates/standard-project/.claude/skills/plan-review/assets/review-checklist.md
+++ b/templates/standard-project/.claude/skills/plan-review/assets/review-checklist.md
@@ -1,0 +1,89 @@
+# Plan Review — {{FEATURE_NAME}}
+
+**Feature:** {{FEATURE_NAME}}  
+**Planning root:** {{PLANNING_ROOT_RELATIVE_PATH}}  
+**Status:** 🔴 Not Ready / 🟡 Needs Work / ✅ Ready  
+**Reviewed:** {{YYYY-MM-DD}}  
+**Scope:** Full plan / Group {{N}} only  
+
+---
+
+## 📋 Plan Structure
+
+- [ ] Implementation plan found and parseable
+- [ ] YAML frontmatter valid (`task_count`, `groups`, `tasks_files`)
+- [ ] Every referenced task group file exists on disk
+- [ ] Checkbox census matches `task_count`
+- [ ] No orphan global task IDs
+
+---
+
+## 📝 Task Group Review
+
+### Group {{N}}: {{GROUP_NAME}} (Tasks {{FROM}}–{{TO}})
+
+- **Header status:** 🔴 / 🟠 / ✅  
+- **Task count:** {{COUNT}} (warn if below 2 or above 8)  
+- **Descriptions:** Adequate / Needs detail  
+- **Dependencies section:** Present / Issues  
+
+*(repeat per reviewed group)*
+
+---
+
+## 🔗 Dependency Validation
+
+- [ ] No circular dependencies
+- [ ] Cross-group references point strictly to earlier groups
+- [ ] External prerequisites documented or flagged
+- [ ] Prerequisite groups complete before downstream execution
+
+---
+
+## 🔄 Consistency Check
+
+- [ ] Plan ↔ Status progress counts align
+- [ ] Plan ↔ Task titles align (no phantom tasks)
+- [ ] Frontmatter `groups[].tasks` matches markdown numbering inside files
+
+---
+
+## 🎓 Prior-stage learning carry-forward
+
+*(Skip section when planning root is `planning/` first stage OR no earlier `planning-stage{prev}/` exists.)*
+
+- [ ] Prior `status-and-next-steps.md` scanned for unresolved narratives / deferred scope
+- [ ] Prior `implementation-plan.md` scanned for unchecked items affecting this stage
+- [ ] Spike / artifact docs explicitly referenced when status mentions them — acknowledged or waived in THIS plan
+
+---
+
+## 🔴 Blockers
+
+*(none)*
+
+---
+
+## 🟡 Warnings
+
+*(none)*
+
+---
+
+## 💡 Recommendations
+
+*(none)*
+
+---
+
+## ✅ Readiness Assessment
+
+**Overall:** Not Ready / Needs Work / Ready  
+
+**Action Items:**
+
+- [ ] {{ACTION_ONE}}
+
+---
+
+**Last Updated:** {{YYYY-MM-DD}}

--- a/templates/standard-project/.claude/skills/plan-review/references/structure.yaml
+++ b/templates/standard-project/.claude/skills/plan-review/references/structure.yaml
@@ -1,0 +1,103 @@
+# Declarative contract for plan-review inputs, review dimensions, and outputs.
+# Read alongside SKILL.md — authoritative glob semantics mirror write-plan parent.
+
+schema_version: 2
+skill: plan-review
+
+invocation_flags:
+  - id: feature
+    description: Explicit planning feature/topic name when multiple trees exist
+    typical_usage: "--feature my-feature"
+  - id: group
+    description: 1-based index into implementation-plan YAML groups array
+    typical_usage: "--group 2"
+  - id: check_deps
+    description: Emphasize dependency validation sections only (still writes full report unless dry-run)
+    typical_usage: "--check-deps"
+  - id: check_tests
+    description: Emphasize test-plan cues inside task markdown when present
+    typical_usage: "--check-tests"
+  - id: dry_run
+    description: Echo review to conversation only; do not write report file
+    typical_usage: "--dry-run"
+
+planning_roots:
+  dev_infra_feature:
+    description: Feature work under admin/services with uniform planning trees
+    base_glob: "admin/services/{service}/features/{feature}/"
+    default_subdir: planning
+    staged_planning_subdir_pattern: "planning-stage{N}/"
+    notes: |
+      Pick exactly ONE subdirectory per invocation: literal `planning/` OR `planning-stage{N}/`
+      where N is a positive integer (e.g. planning-stage3). Never silently merge staged dirs.
+      Record the chosen root in the review report header.
+  template_project:
+    description: Maintainer planning docs inside generated projects
+    base_glob: "docs/maintainers/planning/features/{feature}/"
+    staged_planning_subdir_pattern: null
+
+inputs:
+  singletons:
+    - filename: implementation-plan.md
+      role: YAML frontmatter task index + markdown checkbox mirror of tasks
+    - filename: status-and-next-steps.md
+      role: Progress table, milestones, narrative notes vs plan checkboxes
+  collections:
+    - pattern: "tasks/*.md"
+      role: Per-group task specs referenced by frontmatter groups[].file
+
+prior_stage_carry_forward:
+  description: >
+    When active planning root uses planning-stage{N}/ with N>1, explicitly verify the NEW stage plan
+    incorporates documented learnings from planning-stage{N-1}/ (and linked spikes/PR narratives).
+  suggested_reads:
+    - path_glob: "planning-stage{prev}/status-and-next-steps.md"
+      role: Completed milestones + Notes often contain constraints for next stage
+    - path_glob: "planning-stage{prev}/implementation-plan.md"
+      role: Residual unchecked items / deferred scope markers
+    - path_optional_glob: "**/artifacts/*.md"
+      role: Spike or audit narratives linked from prior status sections
+
+review_dimensions:
+  - id: plan_structure
+    description: Frontmatter internal consistency; checkbox census equals task_count; files exist
+  - id: task_groups
+    description: Group markdown structure; numbering aligns with groups[].tasks; sizing heuristics
+  - id: dependencies
+    description: Ordering within/across groups; external prerequisites; no backward deps
+  - id: consistency
+    description: Plan ↔ status ↔ task titles; phantom/orphan tasks
+  - id: prior_learnings
+    description: Stage-boundary carry-forward — risks called out in prior stage absorbed or consciously waived
+
+report_output:
+  singleton:
+    filename_pattern: "plan-review-{yyyy}-{mm}-{dd}.md"
+    location: Same planning root chosen for inputs (alongside implementation-plan.md)
+    template_asset: assets/review-checklist.md
+  dry_run_destination: conversation_only
+
+implementation_plan_frontmatter:
+  authoritative_parallel: >-
+    Same structural obligations as write-plan/references/structure.yaml —
+    validate task_count, groups[].{name,file,tasks}, tasks_files ordering parity,
+    and global task ID coverage during reviews.
+  required_keys:
+    - task_count
+    - groups
+    - tasks_files
+  group_entry_shape:
+    name: string
+    file: string
+    tasks: list_of_integers
+
+readiness_levels:
+  - id: not_ready
+    label: "🔴 Not Ready"
+    implies: Blockers exist — halt implementation churn on this plan until resolved
+  - id: needs_work
+    label: "🟡 Needs Work"
+    implies: No hard blockers; warnings should be triaged before execution
+  - id: ready
+    label: "✅ Ready"
+    implies: Safe to proceed with scoped execution workflows

--- a/templates/standard-project/.claude/skills/plan-review/references/structure.yaml
+++ b/templates/standard-project/.claude/skills/plan-review/references/structure.yaml
@@ -51,11 +51,14 @@ prior_stage_carry_forward:
     When active planning root uses planning-stage{N}/ with N>1, explicitly verify the NEW stage plan
     incorporates documented learnings from planning-stage{N-1}/ (and linked spikes/PR narratives).
   suggested_reads:
-    - path_glob: "planning-stage{prev}/status-and-next-steps.md"
+    - glob: "planning-stage{prev}/status-and-next-steps.md"
+      optional: false
       role: Completed milestones + Notes often contain constraints for next stage
-    - path_glob: "planning-stage{prev}/implementation-plan.md"
+    - glob: "planning-stage{prev}/implementation-plan.md"
+      optional: false
       role: Residual unchecked items / deferred scope markers
-    - path_optional_glob: "**/artifacts/*.md"
+    - glob: "**/artifacts/*.md"
+      optional: true
       role: Spike or audit narratives linked from prior status sections
 
 review_dimensions:


### PR DESCRIPTION
## Summary

- Adds Stage 3 audit artifact classifying `.cursor/commands/plan-review.md` against ADR-004 tiers and documenting the **`planning-stageN/`** path gap versus **`write-plan`**.
- Ships **`templates/standard-project/.claude/skills/plan-review/`** with `SKILL.md`, **`assets/review-checklist.md`**, and **`references/structure.yaml`** (inputs, review dimensions, prior-stage carry-forward, report naming).
- Aligns planner docs with **`FR-8`** and the five-property rubric table + Gotchas pattern used by **`decision`** / **`write-plan`** families.
- Refreshes **`planning-stage3`** implementation/status/group task docs after merged **PR #94** (Step 0 closeout).

## Why

Group 4 completes the Planner skill trio for Stage 3: **`plan-review`** must mirror **`write-plan`** staged-root semantics and explicitly enforce **prior-stage learning carry-forward**, which the legacy command never spelled out.

## After Merge

- **`new-project.sh`** outputs will include **`plan-review`** under `.claude/skills/` for the standard-project template — downstream repos adopting template sync pick it up on their next merge from dev-infra.
- Legacy **`.cursor/commands/plan-review.md`** remains until Group 5 cutover archives it alongside **`decision`** / **`transition-plan`**.

## Follow-ups

- **Group 5 (Cutover):** Archive **`plan-review.md`** command stub + install pointers; full Stage 3 rubric sweep (`implementation-plan.md` still tracks unchecked rubric rows).
- Optional: refresh **`explore`** pipeline diagrams to insert **`plan-review`** between **`write-plan`** and execution workflows.
