### PR TITLE
feat(agentic-workflow-modernization): Commit and Handoff Skills (Group 2)

### DIFF
--- a/.agents/group-cycle.agent.md
+++ b/.agents/group-cycle.agent.md
@@ -25,7 +25,7 @@ Read these files **before** the step that needs them. Follow each one exactly.
 | Step | Skill / Command | Path |
 |------|----------------|------|
 | Step 0 — post-PR | post-pr | `.cursor/commands/post-pr.md` |
-| Step 0 — pre-phase review | pre-phase-review | `.cursor/commands/pre-phase-review.md` |
+| Step 0 — plan-review (between groups) | plan-review | **Canonical:** `templates/standard-project/.claude/skills/plan-review/SKILL.md` (authoritative semantics + `references/structure.yaml`). **Repo install:** `.claude/skills/plan-review/SKILL.md` when the skill is vendored at repo root — read whichever copy exists in-repo; YAML + assets always align with `templates/standard-project/`. |
 | Step 1 — plan expansion | transition-plan | `.cursor/commands/transition-plan.md` |
 | Step 3 — PR body | update-pr-description | `~/.cursor/skills/update-pr-description/SKILL.md` |
 | Step 4 — PR validation | pr-validation | `.cursor/commands/pr-validation.md` (reference only — Step 4 sub-steps are self-contained) |
@@ -62,9 +62,17 @@ Otherwise close out the previous group cycle:
    group's merged PR (`prior_pr`). Key outputs: status document updates,
    implementation plan checkboxes, deferred Sourcery issue check.
 
-2. **Pre-phase review:** Read `.cursor/commands/pre-phase-review.md` and follow
-   it. Review the prior group's task file and any open questions from its PR.
-   Note adjustments that affect the current group's scope.
+2. **Plan review (between group cycles):** Read the **`plan-review`** Claude skill:
+   **`templates/standard-project/.claude/skills/plan-review/SKILL.md`** (preferred
+   source of truth), **or** **`.claude/skills/plan-review/SKILL.md`** when skills are
+   installed at repo root. Follow that skill exactly — instantiate the checklist from
+   **`assets/review-checklist.md`** and write **`plan-review-YYYY-MM-DD.md`** beside
+   `implementation-plan.md` for the chosen planning subtree (same dated artifact semantics
+   as standalone runs). Narrow scope with `--group N` when validating only the next
+   dispatch footprint. Deprecated slash-command stubs under **`.cursor/commands/pre-phase-review.md`**
+   are thin redirects; do **not** use them as the execution primitive. Produce or refresh
+   the review artifact **after** the prior group's merged PR is reflected in docs and **before**
+   **Step 1** expands or executes the next group's plan.
 
 Both of these happen on the worktree branch before plan expansion begins.
 

--- a/.agents/group-cycle.agent.md
+++ b/.agents/group-cycle.agent.md
@@ -136,9 +136,13 @@ wait for CI to finish.
 gh pr checks [pr-number]
 ```
 
-Document passing/failing checks. If a check fails, check the known issues
-registry at `admin/planning/ci/multi-environment-testing/known-issues.md`. Known
-issues don't block; new failures get 3 retry attempts before stopping.
+Record **current** CI status (passing, failing, or pending). Do not wait for
+pending checks to resolve — Sourcery landing is the only gate for Step 4.
+If checks are still running, note them as pending and continue.
+
+If a check has already **failed**, check the known issues registry at
+`admin/planning/ci/multi-environment-testing/known-issues.md`. Known issues
+don't block; new failures get 3 retry attempts before stopping.
 
 #### 4b. Sourcery Review (dt-review)
 

--- a/.agents/group-cycle.agent.md
+++ b/.agents/group-cycle.agent.md
@@ -65,7 +65,10 @@ Otherwise close out the previous group cycle:
 2. **Plan review (between group cycles):** Read the **`plan-review`** Claude skill:
    **`templates/standard-project/.claude/skills/plan-review/SKILL.md`** (preferred
    source of truth), **or** **`.claude/skills/plan-review/SKILL.md`** when skills are
-   installed at repo root. Follow that skill exactly — instantiate the checklist from
+   installed at repo root. If **neither** path is present in the checked-out tree, read
+   **from the template directory anyway** (or copy `templates/standard-project/.claude/skills/plan-review/`
+   to repo-root **`.claude/skills/plan-review/`**) — do **not** treat missing repo-root
+   install as a signal to use deprecated slash-command stubs. Follow that skill exactly — instantiate the checklist from
    **`assets/review-checklist.md`** and write **`plan-review-YYYY-MM-DD.md`** beside
    `implementation-plan.md` for the chosen planning subtree (same dated artifact semantics
    as standalone runs). Narrow scope with `--group N` when validating only the next

--- a/.claude/skills/plan-review/SKILL.md
+++ b/.claude/skills/plan-review/SKILL.md
@@ -14,6 +14,15 @@ Ensure **uniform planning trees** are internally consistent before `/task` style
 execution. Replaces `.cursor/commands/plan-review.md` with the same behavioral
 contract plus **`planning-stage{N}/`** parity with **`write-plan`**.
 
+**Formal absorption of `/pre-phase-review`:** Operator + agent pipelines now standardize
+on **plan-review** for the “checkpoint before the next tranche of work” role. Use this
+skill **between** dispatched task groups (after the prior group’s work has landed, before
+plan expansion / execution of the next group) so blockers surface early. The dated
+**`plan-review-YYYY-MM-DD.md`** artifact is identical whether run standalone or as a
+pipeline gate — see **`references/structure.yaml`** (`pipeline_integration`). Legacy
+**`/pre-phase-review`** stubs remain only as thin redirects to **`/plan-review`** /
+this skill.
+
 Heavy checklist prose lives in **`assets/review-checklist.md`** — copy into the dated
 review artifact named in **`references/structure.yaml`** (`report_output`).
 
@@ -22,6 +31,10 @@ review artifact named in **`references/structure.yaml`** (`report_output`).
 ## When to use
 
 - Immediately **before** starting work on a new task group when scaffolding exists.
+- **Between task-group dispatches** in long-running agent pipelines (after the prior
+  group merges or fully lands, before you expand/execute the next group) — same dated
+  artifact output as any other invocation; scope with `--group N` when you only need
+  the upcoming group’s footprint reviewed.
 - After **`write-plan-setup`** / **`write-plan-expand`** produced or mutated files.
 - User invokes `/plan-review`, names this skill, or supplies `--check-deps` /
   `--check-tests` emphasis flags.
@@ -141,6 +154,7 @@ Classify findings:
 
 - **`write-plan`** family — upstream scaffolding producer (`write-plan-setup`, `write-plan-expand`).
 - **`decision`** — precedes planning when ADRs justify transition planning.
+- `.cursor/commands/pre-phase-review.md` — deprecated redirect shim → use this skill instead.
 - Retired `/plan-review` command text (read-only history): `admin/archived/commands/stage3-planner/` — **not** an execution prerequisite.
 
 ---

--- a/.claude/skills/plan-review/references/structure.yaml
+++ b/.claude/skills/plan-review/references/structure.yaml
@@ -4,6 +4,14 @@
 schema_version: 2
 skill: plan-review
 
+pipeline_integration:
+  between_group_cycles: >
+    Agentic multi-group pipelines (e.g. group-cycle / agent dispatch) MUST invoke this
+    skill after a merged prior-group PR and before expanding or executing the next
+    task group. Mirrors legacy pre-phase checkpoints while emitting the single
+    `plan-review-{yyyy}-{mm}-{dd}.md` artifact contract (standalone equivalent to ad-hoc runs).
+    Deprecated `/pre-phase-review` command stubs redirect to `/plan-review` / this skill.
+
 invocation_flags:
   - id: feature
     description: Explicit planning feature/topic name when multiple trees exist

--- a/admin/feedback/sourcery/pr98.md
+++ b/admin/feedback/sourcery/pr98.md
@@ -1,0 +1,63 @@
+# Sourcery Review Analysis
+
+**PR**: #98
+**Repository**: grimm00/dev-infra
+**Generated**: Sun May  3 20:10:03 CDT 2026
+
+---
+
+## Summary
+
+Total Individual Comments: 2 + Overall Comments
+
+---
+
+## Individual Comments
+
+### Comment #1
+
+**Type**: issue (bug_risk)
+
+**Description**: The `required_files` sequence currently defines an element as a scalar (`- summary.md`) and then attaches mapping keys (`role`, `optional_extracts`) at the same level, which is not valid YAML. Many parsers will either reject this or drop the extra fields.
+
+<details>
+<summary>Details</summary>
+
+**issue (bug_risk):** YAML structure for `required_files` mixes a scalar item with mapping fields and is likely to be invalid or misparsed.
+
+</details>
+
+---
+
+### Comment #2
+
+**Type**: Explicit token
+
+**Description**: This mixes a plural subject with a singular verb. Please change to something like: “If multiple ambiguous candidates remain without session hints → prompt user — **do not guess**.”
+
+<details>
+<summary>Details</summary>
+
+**issue (typo):** Plural subject should use plural verb (“candidates remain”).
+
+</details>
+
+---
+
+## Overall Comments — triage
+
+| ID | Finding | Resolution |
+|----|---------|------------|
+| OC1 | Step 0 assumed repo-root skill copy always present | Clarified fallback: read/copy from **`templates/standard-project/.claude/skills/plan-review/`** when repo-root install missing — no legacy slash-command stub fallback. |
+| OC2 | `schema_version` drift vs `plan-review` | Raised **commit** + **handoff** `references/structure.yaml` to **`schema_version: 2`**. |
+
+---
+
+## Priority Matrix
+
+| Item | Priority | Impact | Effort | Action |
+|------|----------|--------|--------|--------|
+| #1 (YAML list/map mix under `consumes_review_artifacts`) | HIGH | Parsers may reject coupling metadata | LOW | Fixed — `required_files` / `optional_files` entries use `{ filename:, role: }` maps. |
+| #2 (“candidates remains”) | LOW | Prose polish | LOW | Fixed in `commit/SKILL.md`. |
+| OC1 | MEDIUM | Operator ambiguity on repos without `.claude/skills` install | LOW | Fixed in `.agents/group-cycle.agent.md`. |
+| OC2 | LOW | Skill YAML consistency | LOW | Fixed via `schema_version: 2` on new YAML. |

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage4/artifacts/commit-command-audit.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage4/artifacts/commit-command-audit.md
@@ -1,0 +1,72 @@
+# Audit: `commit` command → commit skill conversion
+
+**Source:** `.cursor/commands/commit.md` (~312 lines)
+**Feature:** agentic-workflow-modernization / Stage 4 — Group 2 — Task 4
+**Date:** 2026-05-03
+**Rubric:** five-property skill contract (*Observable*, *Bounded*, *Outcome-framed*, *Delta-only*, *Failure-aware*) — aligned with Stage 4 prior audits.
+
+---
+
+## Executive summary
+
+| Finding | Detail |
+|---------|--------|
+| Primary value | **Second half of review-then-commit** — verifies staged snapshot, confirms draft message from review artifacts or session, executes `git commit`, optionally deletes transient review folder. |
+| Shape | **Procedural.** Almost entirely git/session/file operations plus human confirmation gates. |
+| Discovery modes | (a) Same-session context from **pre-commit-review**; (b) explicit `review-{desc}-DATE` folder; (c) auto-detect newest `review-*` across artifact bases aligned with **`pre-commit-review/references/structure.yaml`**. |
+| Downstream coupling | **Depends on artifact contract** exported by **`pre-commit-review`** — `summary.md` (`## Draft Commit Message`), optional `diff.patch`, folder dirname pattern — **not** on review skill implementation details. Legacy `/review` naming in command prose maps to **`pre-commit-review`** in skills. |
+
+---
+
+## Coupling to pre-commit-review (explicit)
+
+| Coupling dimension | Commit command behavior | Skill manifestation |
+|--------------------|-------------------------|---------------------|
+| Same-session context | Uses draft message + paths already in conversation | SKILL: prioritize session variables; delta-only cite “see prior workflow” vs re-reading unchanged files unnecessarily |
+| Cross-session artifact | Reads `summary.md` from matched `review-*` folder | SKILL: **`references/structure.yaml`** declares required upstream filenames relative to **`../pre-commit-review/references/structure.yaml`** artifact contract |
+| Auto-detect | `ls -dt` pattern across bases | SKILL: procedural steps mirror **`pre-commit-review`** `review_roots.*.artifact_base_dir` enumeration order for consistency |
+
+---
+
+## Procedural vs behavioral classification
+
+| Region / topic | Procedural | Behavioral | Notes |
+|----------------|------------|------------|-------|
+| Configuration — artifact paths | ● | | Must stay synchronized with **`pre-commit-review`** YAML |
+| Usage / examples | ● | | |
+| §1 Find review context (a–c) | ● | ● | Choosing among multiple folders when ambiguous prompts user |
+| §2 Read `summary.md` | ● | ● | Parsing sections; respecting `--message` override |
+| §3 Verify staged files | ● | ● | Warn on emptiness vs summary drift |
+| §4 Confirm + commit | ● | ● | **Always confirm** commit message |
+| §5 Delete review folder | ● | | `--no-delete` escape hatch |
+| §6 Show result | ● | | |
+| Integration prose | ● | ● | Narrates optimal same-session vs cross-session |
+| Scenarios | ● | ● | |
+| Tips / Important | ● | ● | Conventional-commit reminder — light behavioral |
+
+**Approximate instruction share**
+
+| Bucket | Share |
+|--------|-------|
+| Procedural | **~80%** |
+| Behavioral | **~20%** |
+
+---
+
+## Five-property check (command as-is → skill expectation)
+
+| Property | Pass? | Gap / remediation for skill |
+|----------|-------|------------------------------|
+| **Observable** | Yes | Outcomes = commit hash + retained/deleted folder state; SKILL lists exit states |
+| **Bounded** | Mostly | SKILL must define stop when zero folders / unstaged mismatch after bounded retries |
+| **Outcome-framed** | Yes | Commit + cleanup is clear terminal state |
+| **Delta-only** | Yes | No large pasted templates unlike review; SKILL references **`pre-commit-review`** assets instead duplicating templates |
+| **Failure-aware** | Partial | COMMAND warns unstaged → SKILL **Gotchas** for stale review folder + branch drift |
+
+---
+
+## Decomposition recommendation (Task 5)
+
+1. SKILL at `templates/standard-project/.claude/skills/commit/SKILL.md` — workflow sections mirroring command **Process**.
+2. **`references/structure.yaml`** — declares **dependency link** on **`pre-commit-review/references/structure.yaml`** (`upstream_review_contract`) plus commit-specific options (`--no-delete`, `--message`).
+3. **No `assets/`** — commit produces git objects + optional cleanup only.

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage4/artifacts/group2-integration-validation.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage4/artifacts/group2-integration-validation.md
@@ -1,0 +1,53 @@
+# Integration validation — Group 2 (commit + handoff)
+
+**Feature:** Agentic Workflow Modernization — Stage 4
+**Tasks covered:** Task 8
+**Date:** 2026-05-03
+
+---
+
+## Review ↔ Commit declared coupling
+
+| Check | Result |
+|-------|--------|
+| `commit/references/structure.yaml` includes `upstream_review_contract.skill_id = pre-commit-review` | ✅ |
+| Relative pointer `../pre-commit-review/references/structure.yaml` resolves within `templates/standard-project/.claude/skills/` | ✅ |
+| `consumes_review_artifacts.required_files` lists `summary.md` consistent with **`pre-commit-review/references/structure.yaml`** `required_artifacts` | ✅ |
+| `artifact_bases_must_match_upstream: true` encodes positional parity with reviewer roots | ✅ |
+| SKILL prose references behavioral STOP boundary remains in **pre-commit-review** — commit does **not** restage | ✅ verified by absence of staging instructions |
+
+Residual coordination rule: renaming keys in reviewer YAML mandates paired commit SKILL + YAML update (documented mutual Gotcha).
+
+---
+
+## Handoff standalone rubric (five-property sanity)
+
+| Property | Evidence |
+|----------|----------|
+| Observable | Output path + deterministic template population |
+| Bounded | Explicit detection order + bounded glob search resume |
+| Outcome-framed | Written `handoff-*.md` artifact |
+| Delta-only | Template extracted to **`assets/handoff-template.md`** |
+| Failure-aware | Resume mode enumerates ambiguity + STOP guidance |
+
+---
+
+## FR-8 self-containment (Stage 4 trio)
+
+| Skill | Self-contained? | Notes |
+|-------|------------------|-------|
+| pre-commit-review | Yes | assets + YAML (Group 1) |
+| commit | Yes + pointer | Cross-skill dependency is **declarative file reference**, not command stub |
+| handoff | Yes | No command archive dependency |
+
+---
+
+## Cross-skill ordering sanity
+
+Expected human/agent pipeline: `pre-commit-review → (pause) → commit → (optional) handoff`
+
+Handoff may run without review/commit (independent) — matches planning dependency notes.
+
+---
+
+**Verdict:** ✅ Integration checks satisfied for Tasks 4–8 scope.

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage4/artifacts/group2-integration-validation.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage4/artifacts/group2-integration-validation.md
@@ -10,7 +10,7 @@
 
 | Check | Result |
 |-------|--------|
-| `commit/references/structure.yaml` includes `upstream_review_contract.skill_id = pre-commit-review` | ✅ |
+| `commit/references/structure.yaml` includes `upstream_review_contract.skill_id = pre-commit-review` | ✅ (`schema_version: 2`) |
 | Relative pointer `../pre-commit-review/references/structure.yaml` resolves within `templates/standard-project/.claude/skills/` | ✅ |
 | `consumes_review_artifacts.required_files` lists `summary.md` consistent with **`pre-commit-review/references/structure.yaml`** `required_artifacts` | ✅ |
 | `artifact_bases_must_match_upstream: true` encodes positional parity with reviewer roots | ✅ |

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage4/artifacts/handoff-command-audit.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage4/artifacts/handoff-command-audit.md
@@ -1,0 +1,57 @@
+# Audit: `handoff` command → handoff skill conversion
+
+**Source:** `.cursor/commands/handoff.md` (~190 lines)
+**Feature:** agentic-workflow-modernization / Stage 4 — Group 2 — Task 6
+**Date:** 2026-05-03
+**Rubric:** five-property skill contract (*Observable*, *Bounded*, *Outcome-framed*, *Delta-only*, *Failure-aware*).
+
+---
+
+## Executive summary
+
+| Finding | Detail |
+|---------|--------|
+| Primary value | **Session continuity artifact** — git snapshot + conversational state captured into a transient markdown file for resume or teammate pickup. |
+| Shape | **Procedural** with a **large inline template block** requiring extraction to `assets/handoff-template.md` for Delta-only hygiene. |
+| Path detection | Same three-tier precedent as reviewer/commit: admin/tmp → tmp → lightweight `tests/tmp/`. Lightweight uses **flat** `tests/tmp/handoff-[topic].md` (no `handoffs/` subfolder). |
+| Resume path | **`--resume`** is a distinct procedural branch — search glob `handoff-*.md`, disambiguate if multiple, summarize for assistant context. |
+
+---
+
+## Procedural vs template separation
+
+| Region | Classification | Skill action |
+|--------|----------------|-------------|
+| Configuration / Usage | Procedural | Keep in SKILL Configuration + Usage tables |
+| Gather-context shell blocks | Procedural | Workflow § gather |
+| Markdown **Template** fence | Template **asset** | **Move** verbatim to `assets/handoff-template.md` |
+| `--resume` process | Procedural | Dedicated SKILL section |
+| Tips / Related | Mixed | Compress to Gotchas |
+
+**Approximate share**
+
+| Bucket | Share |
+|--------|-------|
+| Procedural | **~65%** |
+| Template scaffolding | **~25%** |
+| Narrative coaching | **~10%** |
+
+---
+
+## Five-property check
+
+| Property | Pass? | Remediation |
+|----------|-------|--------------|
+| **Observable** | Yes | Output filepath + surfaced document body |
+| **Bounded** | Yes | Topic auto-detect from branch bounded; resume limited to filesystem search |
+| **Outcome-framed** | Yes | Written `handoff-*.md` + user confirmation |
+| **Delta-only** | **Fail (raw)** | Fence must relocate to **`assets/handoff-template.md`** |
+| **Failure-aware** | Partial | SKILL must escalate missing base dirs / non-gitignored destinations |
+
+---
+
+## Decomposition recommendation (Task 7)
+
+1. SKILL at `templates/standard-project/.claude/skills/handoff/SKILL.md`.
+2. `assets/handoff-template.md` — canonical copy of command Template.
+3. `references/structure.yaml` declaring output filename pattern (`handoff-{topic}.md`), root detection rows, **`--resume`** search globs.

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage4/implementation-plan.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage4/implementation-plan.md
@@ -17,7 +17,7 @@ tasks_files:
 ---
 # Implementation Plan — Stage 4: Reviewer (Agentic Workflow Modernization)
 
-**Status:** 🔴 Not Started
+**Status:** 🟠 In Progress
 **Created:** 2026-05-03
 **Last Updated:** 2026-05-03
 **Source:** [design.md Section 5 — Stage 4: Reviewer](../designs/design.md) + Stage 3 learnings
@@ -55,16 +55,16 @@ Convert the **Reviewer** role group of dev-infra commands to skills, completing 
 ## 📝 Implementation Plan
 
 ### Review Skill
-- [ ] Task 1: Audit review command and classify behavioral instructions
-- [ ] Task 2: Convert review to SKILL.md (hybrid: procedural staging + behavioral diff analysis)
-- [ ] Task 3: Validate review skill against review artifact patterns
+- [x] Task 1: Audit review command and classify behavioral instructions
+- [x] Task 2: Convert review to SKILL.md (hybrid: procedural staging + behavioral diff analysis)
+- [x] Task 3: Validate review skill against review artifact patterns
 
 ### Commit and Handoff Skills
-- [ ] Task 4: Audit commit command and classify instructions
-- [ ] Task 5: Convert commit to SKILL.md (procedural, review-coupled)
-- [ ] Task 6: Audit handoff command and classify instructions
-- [ ] Task 7: Convert handoff to SKILL.md (procedural)
-- [ ] Task 8: Validate commit↔review integration and handoff skill
+- [x] Task 4: Audit commit command and classify instructions
+- [x] Task 5: Convert commit to SKILL.md (procedural, review-coupled)
+- [x] Task 6: Audit handoff command and classify instructions
+- [x] Task 7: Convert handoff to SKILL.md (procedural)
+- [x] Task 8: Validate commit↔review integration and handoff skill
 
 ### Cutover and v1 Final Quality Gate
 - [ ] Task 9: Install skills + archive commands (review, commit, handoff)
@@ -75,12 +75,12 @@ Convert the **Reviewer** role group of dev-infra commands to skills, completing 
 
 ## ✅ Definition of Done
 
-- [ ] pre-commit-review skill exists with procedural staging workflow and behavioral diff analysis contract
-- [ ] commit skill exists with review-artifact coupling (same-session + cross-session)
-- [ ] handoff skill exists with create + resume modes
-- [ ] All Stage 4 skills have `assets/` (where applicable) + `references/structure.yaml`
-- [ ] All Stage 4 skills pass five-property rubric with populated gotchas
-- [ ] Self-containment (FR-8) verified for each skill
+- [x] pre-commit-review skill exists with procedural staging workflow and behavioral diff analysis contract
+- [x] commit skill exists with review-artifact coupling (same-session + cross-session)
+- [x] handoff skill exists with create + resume modes
+- [x] All Stage 4 skills have `assets/` (where applicable) + `references/structure.yaml`
+- [ ] All Stage 4 skills pass five-property rubric with populated gotchas *(Group 3 final sweep remainder)*
+- [ ] Self-containment (FR-8) verified for each skill *(trio validated Group 2; full corpus pending Task 11)*
 - [ ] 3 commands archived to `admin/archived/commands/stage4-reviewer/`
 - [ ] CI passes after cutover
 - [ ] Final quality sweep: all ~16 v1 skills pass five-property rubric

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage4/plan-review-2026-05-03.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage4/plan-review-2026-05-03.md
@@ -115,4 +115,27 @@ The plan is structurally sound: frontmatter is internally consistent, task IDs a
 
 ---
 
+## Follow-up — Scoped plan review before Group 2 (commit + handoff)
+
+**Invoked:** Between merged Group 1 PR #97 and expanding/executing Group 2 (`--group 2` posture).  
+**Purpose:** Re-validate the footprint for Tasks 4–8 after Group 1 artifacts (`pre-commit-review`) settled.
+
+### Plan structure (unchanged)
+
+- [x] Frontmatter still coherent; no new phantom task IDs introduced by Group 2 deliverables
+
+### Task Group 2 (Commit and Handoff Skills)
+
+- [x] Dependencies still reference Group 1 review completion (now satisfied)
+- [x] Tasks 4–8 remain executable without new external blockers
+- [x] Acceptance paths map to delivered files: audits under `planning-stage4/artifacts/`, skills under `templates/standard-project/.claude/skills/{commit,handoff}/`
+
+### Readiness
+
+**Label:** ✅ Ready to execute Group 2 / closeout complete
+
+No new blockers; coupling expectations (commit → **pre-commit-review** `structure.yaml`) explicit in plan prose.
+
+---
+
 **Last Updated:** 2026-05-03

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage4/status-and-next-steps.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage4/status-and-next-steps.md
@@ -1,36 +1,35 @@
 # Status & Next Steps — Stage 4: Reviewer
 
-**Status:** 🔴 Not Started
+**Status:** 🟠 In Progress
 **Last Updated:** 2026-05-03
 
 ---
 
 ## 📊 Progress Summary
 
-**Overall:** 0/11 tasks complete
+**Overall:** 8/11 tasks complete
 
 | Group | Status | Progress | Notes |
 |-------|--------|----------|-------|
-| Review Skill | 🔴 Not Started | 0/3 tasks | |
-| Commit and Handoff Skills | 🔴 Not Started | 0/5 tasks | |
-| Cutover and v1 Final Quality Gate | 🔴 Not Started | 0/3 tasks | |
+| Review Skill | ✅ Complete | 3/3 tasks | Landed via PR #97 |
+| Commit and Handoff Skills | ✅ Complete | 5/5 tasks | Audits + skills + integration validation |
+| Cutover and v1 Final Quality Gate | 🔴 Not Started | 0/3 tasks | Next dispatch |
 
 ---
 
 ## 🚀 Next Steps
 
-1. Review scaffolding — verify group/task breakdown.
-2. Expand groups — run write-plan **Expand** for Group 1.
-3. Start implementation — `/agent-dispatch` for Group 1.
+1. Run **plan-review** before Group 3 when ready (after this PR merges) — confirm cutover task specs.
+2. Dispatch **Group 3** — install skills, archive reviewer commands, v1 quality sweep, exit criteria.
 
 ---
 
 ## 📝 Notes
 
 - Stage 4 entry criteria met: Stage 3 go decision logged 2026-05-03
-- Plan generated from design.md Section 5 (Stage 4: Reviewer) on 2026-05-03
-- Conventions carried forward: `assets/` + `references/structure.yaml` from day one (Stage 3 lesson)
-- Archival path follows Stage 3 convention: `admin/archived/commands/stage4-reviewer/`
+- **PR #97** merged 2026-05-03 — Group 1 (pre-commit-review) complete
+- Conventions: `assets/` + `references/structure.yaml`; commit declares coupling via **pre-commit-review** YAML pointer
+- **Group-cycle Step 0** now uses **`plan-review`** skill between groups (`plan-review-YYYY-MM-DD.md`), not legacy `/pre-phase-review` stubs
 
 ---
 

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage4/tasks/01-review-skill.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage4/tasks/01-review-skill.md
@@ -2,26 +2,26 @@
 
 **Feature:** Agentic Workflow Modernization — Stage 4
 **Group:** Review Skill
-**Status:** 🔴 Scaffolding (needs expansion)
+**Status:** ✅ Complete
 **Last Updated:** 2026-05-03
 
 ---
 
 ## 📝 Tasks
 
-- [ ] Task 1: Audit review command and classify behavioral instructions
+- [x] Task 1: Audit review command and classify behavioral instructions
   - Classify review.md (334 lines) against the five-property rubric
   - Separate procedural steps (file identification, staging, artifact capture) from behavioral guidance (what to look for, when to stop)
   - Produce audit artifact at `planning-stage4/artifacts/review-command-audit.md`
 
-- [ ] Task 2: Convert review to SKILL.md (hybrid: procedural staging + behavioral diff analysis)
+- [x] Task 2: Convert review to SKILL.md (hybrid: procedural staging + behavioral diff analysis)
   - Create `templates/standard-project/.claude/skills/pre-commit-review/SKILL.md`
   - Extract summary.md template into `assets/summary-template.md`
   - Create `references/structure.yaml` declaring review artifact output shape
   - Preserve the core behavioral contract: STOP after presenting review, never auto-commit
   - Retain path detection logic (dev-infra / template / lightweight) as procedural steps
 
-- [ ] Task 3: Validate review skill against review artifact patterns
+- [x] Task 3: Validate review skill against review artifact patterns
   - Verify five-property rubric compliance
   - Confirm `references/structure.yaml` accurately declares review outputs
   - Cross-check that review's behavioral "stop" contract is explicit and unambiguous
@@ -38,10 +38,10 @@
 
 ## ✅ Completion Criteria
 
-- [ ] Audit artifact produced
-- [ ] pre-commit-review SKILL.md passes five-property rubric
-- [ ] `assets/` and `references/structure.yaml` present and accurate
-- [ ] "Never auto-commit" behavioral contract preserved
+- [x] Audit artifact produced
+- [x] pre-commit-review SKILL.md passes five-property rubric
+- [x] `assets/` and `references/structure.yaml` present and accurate
+- [x] "Never auto-commit" behavioral contract preserved
 
 ---
 

--- a/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage4/tasks/02-commit-and-handoff-skills.md
+++ b/admin/services/ai-workflow/features/agentic-workflow-modernization/planning-stage4/tasks/02-commit-and-handoff-skills.md
@@ -2,36 +2,36 @@
 
 **Feature:** Agentic Workflow Modernization — Stage 4
 **Group:** Commit and Handoff Skills
-**Status:** 🔴 Scaffolding (needs expansion)
+**Status:** ✅ Complete
 **Last Updated:** 2026-05-03
 
 ---
 
 ## 📝 Tasks
 
-- [ ] Task 4: Audit commit command and classify instructions
+- [x] Task 4: Audit commit command and classify instructions
   - Classify commit.md (312 lines) against the five-property rubric
   - Document coupling to pre-commit-review: same-session context, cross-session artifact reading, auto-detect
   - Produce audit artifact at `planning-stage4/artifacts/commit-command-audit.md`
 
-- [ ] Task 5: Convert commit to SKILL.md (procedural, review-coupled)
+- [x] Task 5: Convert commit to SKILL.md (procedural, review-coupled)
   - Create `templates/standard-project/.claude/skills/commit/SKILL.md`
   - Create `references/structure.yaml` — declare dependency on pre-commit-review's artifact shape (cross-reference pre-commit-review's `structure.yaml`)
   - No `assets/` needed (commit produces commits, not templates)
   - Preserve three discovery modes: same-session context, explicit folder, auto-detect
 
-- [ ] Task 6: Audit handoff command and classify instructions
+- [x] Task 6: Audit handoff command and classify instructions
   - Classify handoff.md (190 lines) against the five-property rubric
   - Separate procedural steps (context gathering, document writing) from template content
   - Produce audit artifact at `planning-stage4/artifacts/handoff-command-audit.md`
 
-- [ ] Task 7: Convert handoff to SKILL.md (procedural)
+- [x] Task 7: Convert handoff to SKILL.md (procedural)
   - Create `templates/standard-project/.claude/skills/handoff/SKILL.md`
   - Extract handoff template into `assets/handoff-template.md`
   - Create `references/structure.yaml` declaring handoff artifact output shape
   - Preserve `--resume` mode as a distinct workflow path
 
-- [ ] Task 8: Validate commit↔review integration and handoff skill
+- [x] Task 8: Validate commit↔review integration and handoff skill
   - Verify commit's `structure.yaml` correctly references review's output shape
   - Verify handoff skill passes five-property rubric independently
   - Confirm all three skills (pre-commit-review, commit, handoff) are self-contained per FR-8
@@ -48,12 +48,12 @@
 
 ## ✅ Completion Criteria
 
-- [ ] Both audit artifacts produced
-- [ ] commit SKILL.md passes five-property rubric
-- [ ] handoff SKILL.md passes five-property rubric
-- [ ] commit `references/structure.yaml` declares review dependency
-- [ ] handoff `assets/` and `references/structure.yaml` present and accurate
-- [ ] FR-8 self-containment verified for all three Stage 4 skills
+- [x] Both audit artifacts produced
+- [x] commit SKILL.md passes five-property rubric
+- [x] handoff SKILL.md passes five-property rubric
+- [x] commit `references/structure.yaml` declares review dependency
+- [x] handoff `assets/` and `references/structure.yaml` present and accurate
+- [x] FR-8 self-containment verified for all three Stage 4 skills
 
 ---
 

--- a/templates/standard-project/.claude/skills/commit/SKILL.md
+++ b/templates/standard-project/.claude/skills/commit/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: commit
+description: >-
+  Finalize staged work after pre-commit-review: confirm draft commit message,
+  run git commit, optionally remove transient review artifacts. Procedural twin
+  to pre-commit-review — never substitutes review judgement. Honors same-session,
+  explicit folder, and auto-detect resolution paths.
+disable-model-invocation: true
+---
+
+# Commit
+
+Complete the **review-then-commit** pipeline **after** **pre-commit-review**
+produced a transient review bundle and (typically) STOPped for human review.
+
+```
+resolve review folder → verify staged snapshot → confirm message → git commit → cleanup (optional)
+```
+
+**Upstream artifact contract:** `references/structure.yaml` declares the stable filenames
+and path roots by **referencing `../pre-commit-review/references/structure.yaml`** — do **not**
+hard-code divergent basename patterns without updating **both** skills.
+
+```
+pre-commit-review  →  STOP + human pause  →  commit (this skill)
+```
+
+---
+
+## When to use
+
+- Immediately after approving a **same-session or cross-session** staged review bundle
+- User says `/commit`, names this skill, or wants finalize without re-running staging
+- Paired workflows: ALWAYS follows **pre-commit-review** — never replaces it
+
+## When not to use
+
+- Changes unstaged / review missing → run **`pre-commit-review`** first
+- Retrospective commentary only → **`narrative`** / journaling flows instead
+
+---
+
+## Configuration
+
+**Review artifact roots (mirror pre-commit-review detection order):**
+
+1. **Dev-Infra:** `admin/tmp/reviews/`
+2. **Template:** `tmp/reviews/`
+3. **Lightweight:** `tests/tmp/reviews/`
+
+**Folder basename pattern:** See upstream `artifact_folder.dirname_pattern` in **`pre-commit-review/references/structure.yaml`**.
+
+**Required coupling files inside folder:** `summary.md` (**draft message** primary); `diff.patch` optional corroboration.
+
+---
+
+## Behavioral contract
+
+| Obligation | Rationale |
+|------------|-----------|
+| **Confirm message + stat** before `git commit` | Preserves human gate from legacy command |
+| **Never manufacture staging** silently | Misaligned staging defeats review intent |
+| **Honor `--message` override** | Operator may correct draft faster than editing summary |
+
+---
+
+## Usage
+
+| Invocation | Behavior |
+|------------|----------|
+| (none) | Auto-resolve folder via precedence in `references/structure.yaml` (`review_folder_resolution_modes`) |
+| `review-topic-YYYY-MM-DD` tail | Narrow search to matching folder |
+| `--no-delete` | Keep transient review artifacts post-commit |
+| `--message "…"` | Skip draft extraction; still show stat + confirm |
+
+---
+
+## Workflow
+
+### 1. Resolve review context *(three-mode precedence)*
+
+1. **Same-session:** If assistant already holds `{review_folder_path, draft_message}` from immediate prior **pre-commit-review**, reuse without disk read when still valid.
+2. **Explicit token:** Match user-supplied substring against basename under each artifact root.
+3. **Auto-latest:** Shell-equivalent aggregation `ls -dt <root>/review-*/ … | head -1` respecting detection order above.
+
+If multiple ambiguous candidates remains without session hints → prompt user — **do not guess**.
+
+Stop + warn when **no candidate** directories exist → suggest rerun **pre-commit-review**.
+
+### 2. Read summary (`summary.md`)
+
+Unless `--message`, parse **Draft Commit Message** section contents.
+
+Skip disk read entirely when trusted session carries identical payload.
+
+### 3. Verify staging
+
+```bash
+git diff --staged --stat
+```
+
+Cases:
+
+| Condition | Action |
+|-----------|--------|
+| Empty staging | Warn stale review; propose re-stage from summary bullets or rerun upstream skill |
+| Mismatch suspicion | Optionally diff-hint vs `diff.patch` |
+
+Never commit empty index.
+
+### 4. Confirm
+
+Present:
+
+1. Final message body
+2. Staged `--stat`
+
+Await explicit confirmation or inline edits **before** `git commit`.
+
+### 5. Commit
+
+Use heredoc or equivalent safe quoting for multi-line conventional commits:
+
+```bash
+git commit -m "$(cat <<'EOF'
+[user confirmed body]
+EOF
+)"
+```
+
+### 6. Cleanup
+
+Unless `--no-delete`, remove resolved review directory (`rm -rf path`).
+
+Echo kept path when retaining.
+
+### 7. Present result
+
+```bash
+git log -1 --oneline
+git status --short
+```
+
+---
+
+## Integration
+
+Compact mental model:
+
+```text
+pre-commit-review ──► STOP + human ──► commit ──► working tree progressing
+```
+
+**Same-session optimum:** eliminates rediscovery latency.
+
+**Cross-session:** deterministic folder search + **`summary.md`**.
+
+---
+
+## Gotchas
+
+- **Contract drift kills automation:** dirname / required files renamed in **pre-commit-review** YAML require simultaneous commit SKILL + YAML tweak.
+- **Stale staging** is frequent when switching branches mid-review — escalate instead of silently committing wrong files.
+- **Multiple reviews:** auto-latest may surprise — prefer explicit basename in busy repos.
+- **`.gitignore` gaps:** transient folders must remain ignored upstream; committing skill does not fix ignore tables.
+
+---
+
+## FR-8 (self-containment)
+
+Executable with **Skills + git** alone; behavior references upstream YAML pointer — not archived command stubs.

--- a/templates/standard-project/.claude/skills/commit/SKILL.md
+++ b/templates/standard-project/.claude/skills/commit/SKILL.md
@@ -83,7 +83,7 @@ pre-commit-review  →  STOP + human pause  →  commit (this skill)
 2. **Explicit token:** Match user-supplied substring against basename under each artifact root.
 3. **Auto-latest:** Shell-equivalent aggregation `ls -dt <root>/review-*/ … | head -1` respecting detection order above.
 
-If multiple ambiguous candidates remains without session hints → prompt user — **do not guess**.
+If multiple ambiguous candidates remain without session hints → prompt user — **do not guess**.
 
 Stop + warn when **no candidate** directories exist → suggest rerun **pre-commit-review**.
 

--- a/templates/standard-project/.claude/skills/commit/references/structure.yaml
+++ b/templates/standard-project/.claude/skills/commit/references/structure.yaml
@@ -1,7 +1,7 @@
 # Declarative contract for commit skill — procedural review consume + cleanup.
 # Read alongside SKILL.md; YAML wins if any prose drifts.
 
-schema_version: 1
+schema_version: 2
 skill: commit
 
 upstream_review_contract:
@@ -13,14 +13,14 @@ upstream_review_contract:
 
 consumes_review_artifacts:
   required_files:
-    - summary.md
+    - filename: summary.md
       role: >-
         SOURCE for draft commit message under heading matching skill prose
         (“## Draft Commit Message” section per pre-commit-summary template).
       optional_extracts:
         - files_changed_list_for_confirmation
   optional_files:
-    - diff.patch
+    - filename: diff.patch
       role: Line-level corroboration if staged snapshot appears stale versus summary.
 
 review_folder_resolution_modes:

--- a/templates/standard-project/.claude/skills/commit/references/structure.yaml
+++ b/templates/standard-project/.claude/skills/commit/references/structure.yaml
@@ -1,0 +1,51 @@
+# Declarative contract for commit skill — procedural review consume + cleanup.
+# Read alongside SKILL.md; YAML wins if any prose drifts.
+
+schema_version: 1
+skill: commit
+
+upstream_review_contract:
+  skill_id: pre-commit-review
+  structure_yaml_relative: ../pre-commit-review/references/structure.yaml
+  notes: >
+    Stable API surface for review→commit coupling. Filename keys, dirname_pattern,
+    and review_roots[].artifact_base_dir MUST stay aligned — coordinate changes atomically across both skills.
+
+consumes_review_artifacts:
+  required_files:
+    - summary.md
+      role: >-
+        SOURCE for draft commit message under heading matching skill prose
+        (“## Draft Commit Message” section per pre-commit-summary template).
+      optional_extracts:
+        - files_changed_list_for_confirmation
+  optional_files:
+    - diff.patch
+      role: Line-level corroboration if staged snapshot appears stale versus summary.
+
+review_folder_resolution_modes:
+  - id: same_session
+    description: Draft path + message already in assistant context after pre-commit-review
+    precedence: highest
+  - id: explicit_name
+    description: User passes folder token matching review dirname tail
+  - id: auto_latest
+    description: Newest lexicographic/mtime ordering across artifact bases from upstream contract
+
+artifact_bases_must_match_upstream: true
+
+git_commands:
+  staged_stat: git diff --staged --stat
+  last_commit_preview: git log -1 --oneline
+
+cli_options:
+  - flag: "--no-delete"
+    effect: Retain transient review folder after successful commit
+  - flag: "--message"
+    effect: Override draft parsed from summary.md
+
+outputs:
+  - id: git_commit
+    description: Conventional-commit message executed on repository
+  - id: transient_review_cleanup
+    description: Deleted review-* folder unless --no-delete

--- a/templates/standard-project/.claude/skills/handoff/SKILL.md
+++ b/templates/standard-project/.claude/skills/handoff/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: handoff
+description: >-
+  Produce a transient handoff markdown artifact capturing git + conversation
+  state for cross-session continuity, or `--resume` the latest prior handoff.
+  Independent of review/commit except when session included those flows.
+disable-model-invocation: true
+---
+
+# Handoff
+
+Maintain **conversation + repository continuity** via an intentionally **ignored**
+Markdown snapshot.
+
+```
+detect layout ──► gather repo facts ──► fill template ──► write file ──► present
+                                              ▲
+                                    assets/handoff-template.md
+```
+
+Declarative filesystem layout expectations — **`references/structure.yaml`** (roots,
+patterns, `--resume` search semantics).
+
+---
+
+## When to use
+
+- End-of-session summaries with concrete next-session steps
+- Teammate handoffs preserving branch + unfinished checklist context
+- After deep review/commit cycles needing durable external memory
+
+## When not to use
+
+- Long-form retrospective insight capture → **`reflect`** (+ narrative tooling)
+- Project-wide health summaries → **`status`**
+
+---
+
+## Configuration
+
+Detection order (**first semantic match wins**):
+
+| Layout | Artifact path |
+|--------|---------------|
+| Dev-Infra (`admin/tmp` or `admin/`) | `admin/tmp/handoffs/handoff-{topic}.md` |
+| Template (`tmp/`) | `tmp/handoffs/handoff-{topic}.md` |
+| Lightweight (fallback) | `tests/tmp/handoff-{topic}.md` |
+
+Transient files **must remain gitignored**.
+
+---
+
+## Behavioral contract
+
+| Obligation | Rationale |
+|------------|-----------|
+| **Never commit artifacts** silently | Operational noise + privacy |
+| **`--resume` shows latest relevant doc** without mutation | Faster cold starts |
+| **Topic default** derivation from git branch basename when omitted | Mirrors legacy ergonomics |
+
+---
+
+## Usage
+
+| Invocation | Behavior |
+|------------|----------|
+| `handoff topic` | Write `handoff-topic.md` in resolved directory |
+| (no topic) | Derive `{topic}` from current branch slug |
+| `--resume` | Search + surface latest `handoff-*.md` |
+
+---
+
+## Workflow — create
+
+### 1. Gather context
+
+```bash
+git branch --show-current
+git log main..HEAD --oneline 2>/dev/null || git log develop..HEAD --oneline
+git diff main..HEAD --stat 2>/dev/null || git diff develop..HEAD --stat
+git status --short
+gh pr list --state open --head "$(git branch --show-current)" 2>/dev/null || true
+```
+
+Record salient conversational milestones not visible in git (decisions, blockers).
+
+### 2. Compose document
+
+Copy **`assets/handoff-template.md`** to resolved output path substituting placeholders.
+
+### 3. Persist + present
+
+Write file ensuring parent directory exists (`mkdir -p`), echo absolute or repo-relative path, display body for verification.
+
+---
+
+## Workflow — `--resume`
+
+1. For each **`references/structure.yaml`** handoff root, expand `**/handoff-*.md` consistent with subdirectory convention (dev-infra/template use trailing `handoffs/`).
+2. If **zero** hits → STOP with guidance (create new handoff instead).
+3. If **many** hits → chronological sort (mtime) SHOW list numbered → wait for explicit pick.
+4. If **exactly one recent** plausible default → DISPLAY summary sections + condensed next-actions.
+
+Never delete files in resume path unless user instructs separately.
+
+---
+
+## Gotchas
+
+- **Missing ignores:** proactively warn committers if artifact path unexpectedly tracked.
+- **Large workspaces:** diff stat only — avoid dumping patch bodies into handoff unintentionally.
+- **Ambiguous slug:** sanitise `{topic}` to safe filename characters `[a-z0-9_-]+`.
+
+---
+
+## FR-8 (self-containment)
+
+Skill + **`assets/handoff-template.md`** + declarative **`references/`** — archived commands not required.

--- a/templates/standard-project/.claude/skills/handoff/assets/handoff-template.md
+++ b/templates/standard-project/.claude/skills/handoff/assets/handoff-template.md
@@ -1,0 +1,54 @@
+# [Topic] - Handoff
+
+**Date:** YYYY-MM-DD
+**Status:** [In Progress | Findings Documented | Blocked | Ready for PR | Ready for Review]
+**Branch:** [current branch]
+**Context:** [1-2 sentence summary of the work]
+
+---
+
+## What Was Done
+
+- [Completed item 1]
+- [Completed item 2]
+- [Completed item 3]
+
+---
+
+## Current State
+
+[Describe where things stand right now. What's working, what's partially done, what files are in what state.]
+
+### Files Changed
+
+- `[file1]` - [what changed and why]
+- `[file2]` - [what changed and why]
+
+### Uncommitted Changes
+
+[List any uncommitted changes and their purpose, or "None - all changes committed"]
+
+---
+
+## What's Left
+
+- [ ] [Remaining task 1]
+- [ ] [Remaining task 2]
+- [ ] [Remaining task 3]
+
+---
+
+## Open Questions
+
+1. [Question that needs answering before proceeding]
+2. [Decision that needs to be made]
+
+---
+
+## How to Continue
+
+[Step-by-step instructions for picking this work back up. Include any commands to run, files to read first, or context that would be helpful.]
+
+1. [First thing to do]
+2. [Second thing to do]
+3. [Third thing to do]

--- a/templates/standard-project/.claude/skills/handoff/references/structure.yaml
+++ b/templates/standard-project/.claude/skills/handoff/references/structure.yaml
@@ -1,5 +1,5 @@
 # Declarative contract for handoff skill — transient markdown artifacts only.
-schema_version: 1
+schema_version: 2
 skill: handoff
 
 handoff_roots:

--- a/templates/standard-project/.claude/skills/handoff/references/structure.yaml
+++ b/templates/standard-project/.claude/skills/handoff/references/structure.yaml
@@ -1,0 +1,34 @@
+# Declarative contract for handoff skill — transient markdown artifacts only.
+schema_version: 1
+skill: handoff
+
+handoff_roots:
+  dev_infra_structure:
+    description: Dev-infra repos with admin tmp layout
+    detect_when:
+      - path_exists: admin/tmp
+      - or_path_exists: admin
+    artifact_dir: admin/tmp/handoffs
+  template_structure:
+    description: Standard generated project layout
+    detect_when:
+      - path_exists: tmp
+    artifact_dir: tmp/handoffs
+  lightweight_structure:
+    description: Minimal tree fallback — file lives directly under tests/tmp/
+    detect_when:
+      - default_fallback: true
+    artifact_dir: tests/tmp
+
+output_file:
+  pattern: handoff-{topic}.md
+  gitignore_expected: true
+
+path_notes: |
+  Dev-infra and template layouts use their `artifact_dir` (each ends with `/handoffs/`).
+  Lightweight layout emits `tests/tmp/handoff-{topic}.md` (flat).
+
+resume_mode:
+  glob: handoff-*.md
+  search_order_roots: identical_to_detect_when_resolution
+  disambiguation: prompt_if_multiple_else_single_display

--- a/templates/standard-project/.claude/skills/plan-review/SKILL.md
+++ b/templates/standard-project/.claude/skills/plan-review/SKILL.md
@@ -14,6 +14,15 @@ Ensure **uniform planning trees** are internally consistent before `/task` style
 execution. Replaces `.cursor/commands/plan-review.md` with the same behavioral
 contract plus **`planning-stage{N}/`** parity with **`write-plan`**.
 
+**Formal absorption of `/pre-phase-review`:** Operator + agent pipelines now standardize
+on **plan-review** for the “checkpoint before the next tranche of work” role. Use this
+skill **between** dispatched task groups (after the prior group’s work has landed, before
+plan expansion / execution of the next group) so blockers surface early. The dated
+**`plan-review-YYYY-MM-DD.md`** artifact is identical whether run standalone or as a
+pipeline gate — see **`references/structure.yaml`** (`pipeline_integration`). Legacy
+**`/pre-phase-review`** stubs remain only as thin redirects to **`/plan-review`** /
+this skill.
+
 Heavy checklist prose lives in **`assets/review-checklist.md`** — copy into the dated
 review artifact named in **`references/structure.yaml`** (`report_output`).
 
@@ -22,6 +31,10 @@ review artifact named in **`references/structure.yaml`** (`report_output`).
 ## When to use
 
 - Immediately **before** starting work on a new task group when scaffolding exists.
+- **Between task-group dispatches** in long-running agent pipelines (after the prior
+  group merges or fully lands, before you expand/execute the next group) — same dated
+  artifact output as any other invocation; scope with `--group N` when you only need
+  the upcoming group’s footprint reviewed.
 - After **`write-plan-setup`** / **`write-plan-expand`** produced or mutated files.
 - User invokes `/plan-review`, names this skill, or supplies `--check-deps` /
   `--check-tests` emphasis flags.
@@ -141,6 +154,7 @@ Classify findings:
 
 - **`write-plan`** family — upstream scaffolding producer (`write-plan-setup`, `write-plan-expand`).
 - **`decision`** — precedes planning when ADRs justify transition planning.
+- `.cursor/commands/pre-phase-review.md` — deprecated redirect shim → use this skill instead.
 - Retired `/plan-review` command text (read-only history): `admin/archived/commands/stage3-planner/` — **not** an execution prerequisite.
 
 ---

--- a/templates/standard-project/.claude/skills/plan-review/references/structure.yaml
+++ b/templates/standard-project/.claude/skills/plan-review/references/structure.yaml
@@ -4,6 +4,14 @@
 schema_version: 2
 skill: plan-review
 
+pipeline_integration:
+  between_group_cycles: >
+    Agentic multi-group pipelines (e.g. group-cycle / agent dispatch) MUST invoke this
+    skill after a merged prior-group PR and before expanding or executing the next
+    task group. Mirrors legacy pre-phase checkpoints while emitting the single
+    `plan-review-{yyyy}-{mm}-{dd}.md` artifact contract (standalone equivalent to ad-hoc runs).
+    Deprecated `/pre-phase-review` command stubs redirect to `/plan-review` / this skill.
+
 invocation_flags:
   - id: feature
     description: Explicit planning feature/topic name when multiple trees exist

--- a/templates/standard-project/.claude/skills/pre-commit-review/references/structure.yaml
+++ b/templates/standard-project/.claude/skills/pre-commit-review/references/structure.yaml
@@ -49,4 +49,7 @@ git_expectations:
 integration:
   commit_skill:
     description: Second half of review-then-commit; consumes same review folder context
-    notes: Declare filenames here so commit SKILL can depend on stable names/paths.
+    sibling_structure_yaml_relative: ../commit/references/structure.yaml
+    notes: >
+      Declare filenames here so commit SKILL can depend on stable names/paths.
+      Companion commit YAML points back via upstream_review_contract for paired edits.


### PR DESCRIPTION
## Summary

- Add Stage 4 **commit** and **handoff** Claude skills under `templates/standard-project/.claude/skills/` (procedural SKILL + `references/structure.yaml`; handoff includes **`assets/handoff-template.md`**).
- Wire **commit** to **pre-commit-review** artifact shape declaratively (`commit/references/structure.yaml` → `upstream_review_contract` pointing at **`../pre-commit-review/references/structure.yaml`**; reciprocal pointer added on review YAML).
- Add planning artifacts: **`commit-command-audit.md`**, **`handoff-command-audit.md`**, **`group2-integration-validation.md`**.
- Align **`.agents/group-cycle.agent.md`** Step 0 between-group checkpoint with **`plan-review`** (`templates/standard-project/.claude/skills/plan-review/SKILL.md` authoritative, `.claude/skills/plan-review/SKILL.md` when vendored); keep **post-pr** semantics unchanged (`post-pr.md`).
- Extend **plan-review** SKILL intro / **When to use** + **`pipeline_integration`** in `references/structure.yaml` so **pre-phase-review** is formally absorbed between task-group dispatches (**`/pre-phase-review`** stubs redirect to **plan-review**); sync `.claude/skills/plan-review/` with template.
- Refresh planning-stage4 navigation: Groups 1–2 progress (**PR #97** absorption + Tasks **4–8**), appendix on **`plan-review-2026-05-03.md`**, implementation plan checkbox updates toward Group 3.

## Why

Completes Stage 4 Group **Commit and Handoff Skills** deliverables ahead of command cutover. Commit must depend on **`pre-commit-review`** (not legacy `review`) YAML contract so integration stays declarative rather than prose drift. Updating **group-cycle** keeps multi-group agent pipelines aligned with the **plan-review** artifact semantics already used for planning gates.

## After Merge

- Template consumers installing `.claude/skills` from **`standard-project`** receive **commit**, **handoff**, and tightened **plan-review** pipeline wording.
- **Group-cycle** runs should read **plan-review** SKILL for Step 0’s planning gate (**after merged prior group work**, **before plan expansion**) instead of invoking deprecated **pre-phase-review** stubs.
- No CI workflow rewrites beyond documentation/skill trees; runtime behavior is documentation + template surface area.

## Follow-ups

- **Group 3** (Tasks **9–11**): install/cutover, archive Stage 4 reviewer commands, full **~16** skill quality sweep, **v1** exit verification.
