### PR TITLE
docs: add narrative origin story and planning for README overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ---
 
-## Why Dev-Infra Exists
+## Why dev-infra Exists
 
 Dev-infra grew out of an apprenticeship where the job was to explore broadly — instructors assigned topics across different domains, from DNS infrastructure to CLI tooling to file servers, with access to company infrastructure and the encouragement to leverage open-source tools and just figure things out. That freedom was valuable, but it created a real problem: projects multiplied faster than they could be tracked. Each new investigation meant a new repo, a new structure, a new set of conventions to remember. Some were active, some were experiments, some should have been archived months ago. Without a consistent approach, the breadth became sprawl.
 
@@ -28,13 +28,13 @@ The answer came through a formal decision process (the same explore → research
 
 That decision clarified everything. It meant fewer, more stable template features instead of shipping every experiment. It meant a two-tier system where dev-infra is deliberately more capable than the templates it produces — and that's by design, not by accident. It also meant the project could iterate on its own workflows without every change rippling into downstream projects.
 
-### What Dev-Infra Has Produced
+### What dev-infra Has Produced
 
 The proof that the patterns work isn't in the templates themselves — it's in the projects running on them. Dev-infra's templates and workflows are the foundation for a growing ecosystem of real projects across different domains and tech stacks:
 
 - **proj-cli** — A command-line tool for project management, built on the standard project template
-- **piHole-DNS** — DNS infrastructure using Pi-hole, structured with dev-infra's hub-and-spoke documentation and planning workflows
-- **OurFileServer** — A file server project using dev-infra's feature-based planning and consistent project organization
+- **pihole-dns** — DNS infrastructure using Pi-hole, structured with dev-infra's hub-and-spoke documentation and planning workflows
+- **ourfileserver** — A file server project using dev-infra's feature-based planning and consistent project organization
 - **work-prod** — Work/production integration, using dev-infra workflows to bridge personal and professional tooling
 - **support-shark** — A support tool leveraging dev-infra's standard project structure and AI-friendly organization
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ But the project quickly became more than templates. Alongside the need to manage
 
 The visible output is a couple of opinionated project templates. The actual product is the system that produces them — a living project with 1,100+ commits, 14 architectural decisions, and patterns running in production across multiple real projects.
 
+### How the Project Found Its Focus
+
+That dual nature — templates and workflows — created a real tension as the project grew. Dev-infra had organically become three things at once: a **laboratory** for experimenting with workflow automation, a **factory** for producing project templates, and a **reference implementation** that used its own tools to build itself. Every improvement became a question: is this a template feature that downstream projects need, or is this internal tooling that only dev-infra uses?
+
+The answer came through a formal decision process (the same explore → research → decide pipeline that dev-infra encodes for other projects). The conclusion: dev-infra's primary identity is **template factory**. Templates are products, not reflections of the internal process. Internal tooling — release automation, validation scripts, the workflow experiments — stays internal. Features have to prove themselves in real use before they graduate into templates.
+
+That decision clarified everything. It meant fewer, more stable template features instead of shipping every experiment. It meant a two-tier system where dev-infra is deliberately more capable than the templates it produces — and that's by design, not by accident. It also meant the project could iterate on its own workflows without every change rippling into downstream projects.
+
 ---
 
 ## 🚀 Quick Start

--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ The answer came through a formal decision process (the same explore → research
 
 That decision clarified everything. It meant fewer, more stable template features instead of shipping every experiment. It meant a two-tier system where dev-infra is deliberately more capable than the templates it produces — and that's by design, not by accident. It also meant the project could iterate on its own workflows without every change rippling into downstream projects.
 
+### What Dev-Infra Has Produced
+
+The proof that the patterns work isn't in the templates themselves — it's in the projects running on them. Dev-infra's templates and workflows are the foundation for a growing ecosystem of real projects across different domains and tech stacks:
+
+- **proj-cli** — A command-line tool for project management, built on the standard project template
+- **piHole-DNS** — DNS infrastructure using Pi-hole, structured with dev-infra's hub-and-spoke documentation and planning workflows
+- **OurFileServer** — A file server project using dev-infra's feature-based planning and consistent project organization
+- **work-prod** — Work/production integration, using dev-infra workflows to bridge personal and professional tooling
+- **support-shark** — A support tool leveraging dev-infra's standard project structure and AI-friendly organization
+
+Each of these projects started from a dev-infra template and inherited the same documentation patterns, planning workflows, and organizational conventions. That consistency is what makes it possible to context-switch between a DNS project and a CLI tool without re-learning how the project is organized — the original problem that dev-infra was built to solve.
+
 ---
 
 ## 🚀 Quick Start

--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@
 
 ---
 
+## Why Dev-Infra Exists
+
+Dev-infra grew out of an apprenticeship where the job was to explore broadly — instructors assigned topics across different domains, from DNS infrastructure to CLI tooling to file servers, with access to company infrastructure and the encouragement to leverage open-source tools and just figure things out. That freedom was valuable, but it created a real problem: projects multiplied faster than they could be tracked. Each new investigation meant a new repo, a new structure, a new set of conventions to remember. Some were active, some were experiments, some should have been archived months ago. Without a consistent approach, the breadth became sprawl.
+
+The initial trigger was noticing that the same patterns kept emerging across unrelated projects. A full-stack app (Pokehub), a command-line tool (dev-toolkit), and a learning project (Containers) all converged on similar organizational structures, similar documentation approaches, similar planning workflows. The thought was: it would be useful to start new projects, revisit old ones, and read others' projects with a systematic way of understanding them — a consistent landing surface regardless of tech stack, domain, or level of activity.
+
+But the project quickly became more than templates. Alongside the need to manage project lifecycles, there was a parallel need to develop workflows for refining thinking itself — structured approaches to exploring problems, conducting research, making architectural decisions, and planning implementation before writing code. These two needs started as one ("I need structure") and dev-infra is where they converge: the templates provide consistent project organization, while the workflow system (skills like explore, research, decide, plan) encodes engineering rigor into repeatable patterns.
+
+The visible output is a couple of opinionated project templates. The actual product is the system that produces them — a living project with 1,100+ commits, 14 architectural decisions, and patterns running in production across multiple real projects.
+
+---
+
 ## 🚀 Quick Start
 
 ### 1. Get Dev-Infra

--- a/admin/feedback/sourcery/pr103.md
+++ b/admin/feedback/sourcery/pr103.md
@@ -1,0 +1,70 @@
+# Sourcery Review Analysis
+**PR**: #103
+**Repository**: grimm00/dev-infra
+**Generated**: Thu May 14 16:37:19 CDT 2026
+
+---
+
+## Summary
+
+Total Individual Comments: 1 + Overall Comments
+
+## Individual Comments
+
+### Comment #1
+
+**Type**: suggestion (typo)
+
+**Description**: Since this is the project name, choose a single capitalization and use it consistently within this section and ideally across the README.
+
+<details>
+<summary>Details</summary>
+
+<b>Code Context</b>
+
+<pre><code>
++## Why Dev-Infra Exists
+</code></pre>
+
+<b>Issue</b>
+
+**suggestion (typo):** Consider normalizing the capitalization of &quot;Dev-Infra&quot; / &quot;Dev-infra&quot; in this section.
+
+</details>
+
+---
+
+## Overall Comments
+
+- In the README narrative planning files, the overall feature status in `status-and-next-steps.md` (🔴 Not Started) conflicts with the reported progress (3/9 tasks complete) and the 🟠 In Progress status in `implementation-plan.md`; align these status fields and next-step notes so they accurately reflect current progress.
+- The new README narrative and planning docs use inconsistent naming for downstream projects (e.g., `piHole-DNS` vs `pi-hole DNS`); standardize these identifiers across the README and meta docs so readers can reliably map references to the same projects.
+
+## Priority Matrix Assessment
+
+Use this template to assess each comment:
+
+| Comment | Priority | Impact | Effort | Action | Notes |
+|---------|----------|--------|--------|--------|-------|
+| #1 (capitalization) | 🟡 MEDIUM | 🟡 MEDIUM | 🟢 LOW | Fix now | Normalize to "dev-infra" (lowercase) consistently |
+| Overall #1 (status conflict) | 🟠 HIGH | 🟡 MEDIUM | 🟢 LOW | Fix now | status-and-next-steps.md header still says 🔴 Not Started |
+| Overall #2 (project naming) | 🟡 MEDIUM | 🟡 MEDIUM | 🟢 LOW | Fix now | Standardize downstream project names across all docs |
+
+### Priority Levels
+- 🔴 **CRITICAL**: Security, stability, or core functionality issues
+- 🟠 **HIGH**: Bug risks or significant maintainability issues
+- 🟡 **MEDIUM**: Code quality and maintainability improvements
+- 🟢 **LOW**: Nice-to-have improvements
+
+### Impact Levels
+- 🔴 **CRITICAL**: Affects core functionality
+- 🟠 **HIGH**: User-facing or significant changes
+- 🟡 **MEDIUM**: Developer experience improvements
+- 🟢 **LOW**: Minor improvements
+
+### Effort Levels
+- 🟢 **LOW**: Simple, quick changes
+- 🟡 **MEDIUM**: Moderate complexity
+- 🟠 **HIGH**: Complex refactoring
+- 🔴 **VERY_HIGH**: Major rewrites
+
+

--- a/admin/services/ai-workflow/explorations/skill-package-controller/README.md
+++ b/admin/services/ai-workflow/explorations/skill-package-controller/README.md
@@ -1,0 +1,26 @@
+# Skill Package Controller — Exploration
+
+**Created:** 2026-05-06
+**Service:** ai-workflow
+**Status:** 🟠 In Progress
+
+---
+
+## Quick Links
+
+- [Exploration](exploration.md) — themes, questions, spike determination
+- [Research Topics](research-topics.md) — prioritized questions for investigation
+
+## Overview
+
+Explores the **controller** layer of the ai-workflow package: the runtime component that detects repo context, manages a persistent registry of repo relationships, bootstraps new repos via setup flow, and passes resolved configuration to skills/agents/commands. Distinct from individual skill path overrides (which are the *endpoints* of what the controller provides) and from the meta-level skill-template-separation question (which determines *what authority the controller carries*).
+
+## Related
+
+- [Skill-Template Separation](../../../meta/explorations/skill-template-separation/) — meta exploration; Themes 1–2 decisions directly constrain controller scope
+- [skills-path-roots-configurable.md](../../../../planning/opportunities/internal/dev-infra/improvements/skills-path-roots-configurable.md) — immediate skill-level fixes the controller would subsume
+- [per-repo-skill-profile-unified.md](../../../../planning/opportunities/internal/dev-infra/improvements/per-repo-skill-profile-unified.md) — unified profile (the registry shape) the controller manages
+
+---
+
+**Last Updated:** 2026-05-06

--- a/admin/services/ai-workflow/explorations/skill-package-controller/exploration.md
+++ b/admin/services/ai-workflow/explorations/skill-package-controller/exploration.md
@@ -1,0 +1,107 @@
+# Exploration: Skill Package Controller
+
+**Created:** 2026-05-06
+
+---
+
+## 🎯 What We're Exploring
+
+The ai-workflow skills, agents, and commands currently operate as independent units with no shared runtime. Each skill re-derives repo context, detects paths, and makes assumptions about structure in isolation. What's missing is a **controller** — the component that fires before any skill, identifies the repo, consults persistent state, and hands resolved context downstream. This exploration maps out what that controller is, what it manages, and how it interacts with the registry (per-repo profile), the bootstrapping flow (setup), and the authority model (AGENTS.md vs external config vs inference).
+
+---
+
+## 🔍 Themes
+
+### Theme 1: The Controller as Shared Entry Point
+
+- Skills today have no shared dispatcher — each does its own detection, leading to repeated path-resolution logic across `pre-commit-review`, `commit`, `write-plan`, etc.
+- The superpowers `using-superpowers` hook is proto-controller: it fires at session start, checks for applicable skills, and sets behavioral context — but it doesn't manage state or pass resolved config
+- The controller's job: (1) identify current repo, (2) consult registry for relationship state, (3) decide if setup is needed, (4) pass resolved workspace root and paths to the invoked skill
+- This eliminates the DRY violation where each skill independently implements "flag → config → fallback" resolution — the controller resolves once, skills consume
+- The controller is what makes "package-level" behavior possible: install the package, get a runtime that coordinates across all its constituent skills
+- Implementation form is likely a session hook (Cursor) or preamble include — something that fires before skill-specific logic regardless of which skill was invoked
+
+### Theme 2: The Registry as Persistent State (Model Layer)
+
+- Every skill invocation in a repo is a potential registry write: "I ran here, here's what I observed"
+- Registry entries track relationship status between the package and each repo: AGENTS.md presence/location, setup state, workspace root, resolved paths
+- The `ticket-intake/repos/<slug>.yaml` precedent is the first instance of this registry — it stores per-repo conventions externally without touching the repo
+- The unified profile proposal (`per-repo-skill-profile-unified.md`) sketches the shape: `schema_version`, `ticket`, `paths` sections — but it doesn't yet account for the controller's metadata (setup state, AGENTS.md detection, last-seen timestamp)
+- The registry makes the package stateful across sessions: a new conversation doesn't start from zero but picks up where the last one left off
+- Write authority should belong to the controller (single writer), not to individual skills (many writers, conflict risk)
+- Open shape question: does the registry entry grow a `controller:` section for its own metadata, or does controller metadata live separately from skill-consumed config?
+
+### Theme 3: The Bootstrapping Flow (Setup / Onboarding)
+
+- When the controller runs in a repo it hasn't seen before (no registry entry), it should offer setup rather than silently proceeding with degraded detection
+- Setup flow: "I don't see an AGENTS.md or a config for this repo. Want me to learn about your repo and store that so I can help better?"
+- The user can choose: (a) generate an AGENTS.md in-repo, (b) generate understanding externally in the package's config directory, (c) decline — the package operates in degraded/fallback mode
+- "Completely leave the user's repo alone" is a first-class option — the package functions as a guest, never requiring write access to the repo it operates in
+- The derived AGENTS.md is not a template fill-in-the-blanks but an observed understanding: "I looked at your repo, here's what I see, here's where I'll put artifacts"
+- Setup should be idempotent: re-running it updates the registry without clobbering user customizations
+- The setup trigger could be: first skill invocation in unknown repo, explicit user command (`/setup`), or a session hook detecting a new `pwd`
+
+### Theme 4: The Three-Tier Authority Model
+
+- Tier 1: AGENTS.md in repo root — authoritative, the repo's own opinion about itself
+- Tier 2: Package's external registry for this repo — package-managed understanding, user-customizable
+- Tier 3: Runtime inference / detection heuristics — degraded mode, triggers setup offer
+- The controller's resolution chain: check Tier 1, then Tier 2, then Tier 3. Skills never need to know which tier the answer came from — they get a resolved value
+- AGENTS.md presence doesn't eliminate the registry — the registry may store derived/cached values and controller metadata even when AGENTS.md exists
+- The meta exploration's Theme 2 (template minimalism) decision affects whether Tier 1 is common or rare: if templates become minimal, most repos won't *have* an AGENTS.md on day one, making Tier 2 (the registry) the primary path for most users
+- This is the same "flag → config → fallback" pattern from the skill-path-roots int-opp, but elevated to the package level
+
+### Theme 5: Prior Art and Platform Convergence
+
+- The `using-superpowers` hook already fires at session start in Cursor — it's the closest thing to a controller today
+- Cursor hooks (`~/.cursor/hooks/`) provide the mechanical seam for triggering the controller on session start
+- The emerging agentskills.io standard suggests convergence on AGENTS.md as the agent instruction file — the controller's Tier 1 aligns with this
+- Claude Code's CLAUDE.md, Cursor's `.cursor/rules/`, and the agentskills.io AGENTS.md are all the same concept in different namespaces — the controller should be namespace-agnostic in its Tier 1 detection
+- XDG Base Directory Specification provides the model for package-level config storage: `~/.config/ai-workflow/repos/<slug>.yaml` (config), `~/.local/state/ai-workflow/` (state) — separating config the user edits from state the controller manages
+- The Cursor-specific installation (`~/.cursor/skills/`, `~/.cursor/repos/`) was pragmatic for single-user single-editor use, but doesn't generalize; XDG or a similar convention makes the package editor-agnostic even if only one editor is supported initially
+
+### Theme 6: Meta Prerequisites and Parallel Work
+
+- The skill-template-separation exploration (meta service) makes decisions that constrain controller scope — specifically Theme 1 (skills as their own concern) and Theme 2 (template minimalism)
+- If templates become minimal, the controller's setup flow becomes *mandatory infrastructure* not optional enhancement — most repos won't have pre-built structure
+- If skills are their own concern (not template products), the controller's authority is skill-authored, not template-imposed
+- **What can proceed in parallel to meta decisions:** the controller's mechanical implementation (hook, registry read/write, resolution chain), the registry schema for currently-known fields, the setup flow UX, and the `pre-commit-review`/`commit` path-root fixes
+- **What's blocked on meta decisions:** the full registry schema (what sections exist depends on what templates stop providing), whether AGENTS.md generation is part of setup or separate, the naming/location of the package's config directory (depends on whether the package is "ai-workflow" or something else)
+- The handoff (`handoff-ai-skill-improvements.md`) explicitly advises "hold on the unified profile schema until meta research on Themes 1–2 lands" — this exploration's parallel-work items respect that boundary
+
+---
+
+## ❓ Key Questions
+
+1. What's the minimal controller implementation that provides value now — is it just "resolve workspace root and pass it to skills" or does it need the full registry/setup flow?
+2. Should the controller's config/state use XDG conventions (`~/.config/ai-workflow/`, `~/.local/state/ai-workflow/`) or stay under `~/.cursor/` for now with a migration path later?
+3. How does the controller detect "new repo" vs "known repo" — repo slug from `git remote`, basename of cwd, or something more robust?
+4. What's the trigger mechanism — Cursor session hook, skill preamble include, or something else? Does it need to work across Cursor, Claude Code, and raw CLI?
+5. Should the setup flow produce AGENTS.md by default (in-repo) or external-only by default (guest mode)? What heuristic determines the default offer?
+6. How does the registry handle repos with no git remote (local-only projects, monorepo subdirectories)?
+7. Can the controller's resolution chain be implemented as a standalone utility (shell script, yq helper) that skills call, or does it need to be a hook that runs *before* skills?
+
+---
+
+## 🧪 Spike Determination
+
+| Topic | Risk Level | Spike? | Rationale |
+|-------|------------|--------|-----------|
+| Controller as session hook | MEDIUM | No | The `using-superpowers` hook proves the mechanical approach works. Research on trigger mechanisms is sufficient — no hard-to-reverse decisions. |
+| Registry schema | MEDIUM | No | The unified profile int-opp already sketches the shape. Extending it with controller metadata is additive. Research on XDG vs Cursor-local is sufficient. |
+| Bootstrapping/setup flow | MEDIUM-HIGH | Consider | The UX of "detect unknown repo, offer setup, derive understanding" is genuinely unclear. A spike building a minimal setup command and testing it on 2–3 repos would surface what the flow actually needs to ask/observe. |
+| Three-tier authority resolution | LOW | No | The resolution chain is a well-understood pattern (flag → config → fallback). Implementation is straightforward once the registry location is decided. |
+| XDG vs Cursor-local storage | LOW | No | This is a decision about naming/location, not a technical risk. Can be made after a brief research pass on conventions. |
+| Platform convergence (multi-editor) | LOW | No | Only Cursor is supported now. The abstraction is worth having, but building for multiple editors is YAGNI until a second editor is actually used. Research the emerging standards; don't implement multi-editor support. |
+
+**Risk framework:** HIGH = spike first (hard to pivot), MEDIUM-HIGH = consider spike, MEDIUM/LOW = research only.
+
+---
+
+## 🚀 Next Steps
+
+Review this exploration, then:
+- `/explore-amend` to add new themes from downstream discovery
+- `/research --from-explore skill-package-controller` to investigate open questions
+- The setup/bootstrapping theme (MEDIUM-HIGH risk) may benefit from a `/spike` — build a minimal `setup` command and test it against 2–3 real repos to see what it needs to observe
+- Items that can proceed **in parallel to meta exploration research**: controller hook mechanism (Question 4), registry slug derivation (Question 3), XDG convention research (Question 2), and the immediate `pre-commit-review`/`commit` path-root fixes from the handoff

--- a/admin/services/ai-workflow/explorations/skill-package-controller/exploration.md
+++ b/admin/services/ai-workflow/explorations/skill-package-controller/exploration.md
@@ -1,6 +1,7 @@
 # Exploration: Skill Package Controller
 
 **Created:** 2026-05-06
+**Amended:** 2026-05-06 — discussion surfaced stateless dispatch model and issue #102 connection
 
 ---
 
@@ -69,6 +70,25 @@ The ai-workflow skills, agents, and commands currently operate as independent un
 - **What's blocked on meta decisions:** the full registry schema (what sections exist depends on what templates stop providing), whether AGENTS.md generation is part of setup or separate, the naming/location of the package's config directory (depends on whether the package is "ai-workflow" or something else)
 - The handoff (`handoff-ai-skill-improvements.md`) explicitly advises "hold on the unified profile schema until meta research on Themes 1–2 lands" — this exploration's parallel-work items respect that boundary
 
+### Theme 7: Stateless Dispatch, Filesystem-Backed Statefulness
+
+- The controller/dispatch is stateless at invocation time — it reads filesystem state, resolves, and hands off. No daemon, no in-memory persistence, no session carryover required
+- The *system* is stateful (registry files accumulate over time) but any individual invocation is a pure read-resolve-handoff — same model as `git config`, `direnv`, `mise`
+- This means dispatch can't become a god object (issue #102's concern about unified dispatch complexity) — it doesn't accumulate runtime state, it just knows where to look
+- Registry writes don't need to happen during dispatch. They can be post-hooks ("update last-seen, record observations") or explicit setup commands. The dispatch path stays fast and predictable — never blocks on a write
+- A stateful server or daemon is a possible future layer but not a prerequisite — file-based config/state is sufficient and proven at this scale
+- This is the architectural answer to "how does the package remember things across sessions without becoming complex": it doesn't remember anything in-process; it reads files that persist
+
+### Theme 8: Connection to Issue #102 — Agent Architecture and Unified Dispatch
+
+- Issue #102 ("Agent architecture: directory-based agents with skill manifests and unified dispatch") works the same problem from the agent-orchestration angle
+- Thread 5 ("Agents Hired by Projects") is the bootstrapping/registry concept as metaphor: agents come with a toolbox (skills manifest) and a resume; a project "hires" them by dispatching. The controller mediates between project needs (AGENTS.md / registry) and package capabilities (manifest)
+- Thread 4 ("Unified Dispatch") is the controller by another name — and the concern about it becoming a god object is resolved by Theme 7's stateless-dispatch model
+- Thread 3 ("Skill Concerns vs Agent Concerns") gives the layer boundary: skills = atomic contracts, agents = orchestration, controller = neither. The controller is runtime substrate both consume
+- Thread 2 ("Agents as Skill Collections / Directory Pattern") connects to the package framing: if agents become directories with manifests, the manifest is what the controller reads to know "what does this agent need from the registry?"
+- The statefulness dimension (Theme 2, Theme 7) is what issue #102 doesn't yet have — it frames dispatch as stateless matching, but the registry adds cross-session memory. This is an extension, not a contradiction
+- Source: `/discuss` session reviewing issue #102 against the exploration
+
 ---
 
 ## ❓ Key Questions
@@ -80,6 +100,8 @@ The ai-workflow skills, agents, and commands currently operate as independent un
 5. Should the setup flow produce AGENTS.md by default (in-repo) or external-only by default (guest mode)? What heuristic determines the default offer?
 6. How does the registry handle repos with no git remote (local-only projects, monorepo subdirectories)?
 7. Can the controller's resolution chain be implemented as a standalone utility (shell script, yq helper) that skills call, or does it need to be a hook that runs *before* skills?
+8. If dispatch is stateless (read-resolve-handoff), where and when do registry writes happen — post-hook after skill execution, explicit setup command, or both?
+9. How does this controller concept unify with issue #102's "unified dispatch" — are they the same component, or is the controller a substrate that the dispatcher consumes?
 
 ---
 
@@ -93,6 +115,8 @@ The ai-workflow skills, agents, and commands currently operate as independent un
 | Three-tier authority resolution | LOW | No | The resolution chain is a well-understood pattern (flag → config → fallback). Implementation is straightforward once the registry location is decided. |
 | XDG vs Cursor-local storage | LOW | No | This is a decision about naming/location, not a technical risk. Can be made after a brief research pass on conventions. |
 | Platform convergence (multi-editor) | LOW | No | Only Cursor is supported now. The abstraction is worth having, but building for multiple editors is YAGNI until a second editor is actually used. Research the emerging standards; don't implement multi-editor support. |
+| Stateless dispatch model | LOW | No | Well-understood pattern (git config, direnv, mise). No hard-to-reverse decisions — it's a design constraint, not a technical risk. |
+| Issue #102 unification | MEDIUM | No | Conceptual alignment work — determining whether the controller IS the unified dispatch or feeds into it. Research and discussion are sufficient; no code risk. |
 
 **Risk framework:** HIGH = spike first (hard to pivot), MEDIUM-HIGH = consider spike, MEDIUM/LOW = research only.
 

--- a/admin/services/ai-workflow/explorations/skill-package-controller/research-topics.md
+++ b/admin/services/ai-workflow/explorations/skill-package-controller/research-topics.md
@@ -1,0 +1,67 @@
+# Research Topics — Skill Package Controller
+
+**Created:** 2026-05-06
+
+---
+
+## 📋 Topics Identified
+
+### Topic 1: Controller Trigger Mechanism
+
+**Question:** What's the right invocation point for the controller — Cursor session hook, shared skill preamble, or something else — and how does it generalize across editors?
+**Priority:** High
+**Context:** The controller must fire *before* any skill-specific logic. The `using-superpowers` hook proves session hooks work in Cursor, but Claude Code and CLI agents have different entry points. The mechanism chosen determines portability.
+**Parallel-safe:** Yes — this is mechanical/platform research, independent of meta decisions.
+
+### Topic 2: Registry Storage Convention (XDG vs Cursor-local)
+
+**Question:** Should the package's persistent state use XDG Base Directory conventions (`~/.config/ai-workflow/`, `~/.local/state/ai-workflow/`) or remain under `~/.cursor/` with a future migration path?
+**Priority:** High
+**Context:** The current `~/.cursor/repos/` location couples the package to Cursor. XDG is the POSIX standard for application config/state separation. The choice affects every path the controller reads/writes and determines whether the package is editor-portable by default.
+**Parallel-safe:** Yes — storage convention is independent of what the registry *contains*.
+
+### Topic 3: Repo Identity and Slug Derivation
+
+**Question:** How should the controller uniquely identify a repo — `basename` of remote URL, full `org/repo` from remote, hash, or cwd-based? How does it handle repos with no remote or monorepo subdirectories?
+**Priority:** Medium
+**Context:** The `ticket-intake` precedent uses `basename $(git remote get-url origin) .git`. This fails for repos with the same name under different orgs, local-only repos, and monorepo sub-paths. The slug is the registry's primary key — getting it wrong means collisions or orphaned entries.
+**Parallel-safe:** Yes — slug derivation is a utility concern, not blocked on meta decisions.
+
+### Topic 4: Setup Flow UX — What Does Onboarding Actually Need?
+
+**Question:** When the controller encounters an unknown repo, what questions does it need to ask, what can it infer, and what's the minimal viable interaction?
+**Priority:** High
+**Context:** The bootstrapping flow should feel helpful, not interrogative. It needs to balance "derive understanding without asking" (scan for structure, read existing config files) with "confirm assumptions before acting." The UX determines whether users accept or skip setup.
+**Parallel-safe:** Partially — the *what to ask* depends on what the registry stores, which partially depends on meta decisions about template minimalism. The *how to ask* (interaction pattern, trigger, opt-out) is independent.
+
+### Topic 5: AGENTS.md as Tier 1 — Detection and Derivation
+
+**Question:** What should the controller look for when checking Tier 1 (in-repo authority)? Just `AGENTS.md` at root, or also `CLAUDE.md`, `.cursor/rules/`, and other namespace variants? If deriving one, what does a useful generated AGENTS.md contain?
+**Priority:** Medium
+**Context:** The agentskills.io emerging standard converges on AGENTS.md, but real repos have CLAUDE.md, .cursorrules, etc. The controller needs to know what counts as "repo has declared its own context." If setup *generates* one, it should produce something the repo maintainer would keep.
+**Parallel-safe:** Yes — detection heuristics are independent of meta decisions.
+
+### Topic 6: Package-Level vs Skill-Level Config Separation
+
+**Question:** Where's the boundary between what the controller manages (package-level: workspace root, setup state, AGENTS.md cache) and what individual skills manage (skill-level: specific artifact paths, formatting preferences)?
+**Priority:** Medium
+**Context:** The unified profile int-opp proposes one file with sections per concern. But the controller/skill boundary question is: does the controller *resolve* skill-specific paths (centralizing all resolution), or does it provide the *inputs* (workspace root, repo slug) and let skills resolve their own paths from there? The former is simpler for skills; the latter is more extensible.
+**Parallel-safe:** Partially — the boundary depends on how many concerns the controller takes on, which depends on how minimal templates become (meta Theme 2).
+
+### Topic 7: Prior Art — Existing Package Managers and Dev Tool Controllers
+
+**Question:** How do comparable tools (direnv, asdf/mise, devcontainers, nix flakes) handle per-project config discovery, bootstrapping, and resolution chains? What patterns are proven?
+**Priority:** Low
+**Context:** Avoids reinventing known patterns. `direnv` does "detect `.envrc`, resolve hierarchically." `mise` does "detect `.tool-versions` or `mise.toml`, support global fallback." These are the same problem: per-project config with a global default. Their UX decisions (opt-in vs opt-out, file-in-repo vs external) are directly relevant.
+**Parallel-safe:** Yes — pure research, no dependencies.
+
+---
+
+## 🚀 Next Steps
+
+Use `/research --from-explore skill-package-controller` to investigate these questions.
+
+**Recommended parallel tracks:**
+- Topics 1, 2, 3, 7 can proceed immediately (no meta dependencies)
+- Topic 4 can proceed on the "how to ask" dimension; "what to ask" is partially blocked
+- Topics 5, 6 can proceed with current assumptions and update when meta Themes 1–2 land

--- a/admin/services/ai-workflow/explorations/skill-package-controller/research-topics.md
+++ b/admin/services/ai-workflow/explorations/skill-package-controller/research-topics.md
@@ -55,6 +55,20 @@
 **Context:** Avoids reinventing known patterns. `direnv` does "detect `.envrc`, resolve hierarchically." `mise` does "detect `.tool-versions` or `mise.toml`, support global fallback." These are the same problem: per-project config with a global default. Their UX decisions (opt-in vs opt-out, file-in-repo vs external) are directly relevant.
 **Parallel-safe:** Yes — pure research, no dependencies.
 
+### Topic 8: Stateless Dispatch — Write Timing and Post-Hooks
+
+**Question:** If dispatch is a pure read-resolve-handoff, when and how do registry writes happen? Should writes be post-skill-execution hooks, explicit setup commands, or opportunistic (write-if-changed)?
+**Priority:** Medium
+**Context:** The stateless dispatch model means the fast path (read config, resolve, hand off) never blocks on writes. But the registry still needs to be updated — last-seen timestamps, newly observed repo structure, setup state changes. The write timing affects whether skills need to be aware of the registry at all or whether the controller handles all persistence transparently.
+**Parallel-safe:** Yes — write timing is a design decision independent of meta exploration outcomes.
+
+### Topic 9: Relationship Between Controller and Issue #102 Unified Dispatch
+
+**Question:** Is the controller the same component as issue #102's "unified dispatch," or is it a lower-level substrate that the dispatcher consumes? If they're the same, how does the controller avoid becoming the "god object" #102 warns about?
+**Priority:** Medium
+**Context:** Issue #102 proposes unified dispatch (routing to agents by category/name/intent) and warns about god-object risk. The controller explored here resolves context and passes it downstream. These might be the same thing (dispatch = resolve context + route to agent) or two layers (controller = resolve context; dispatcher = route to agent using that context). Clarifying the boundary determines whether this exploration subsumes #102's dispatch thread or feeds into it.
+**Parallel-safe:** Yes — conceptual alignment work, no implementation dependencies.
+
 ---
 
 ## 🚀 Next Steps

--- a/admin/services/meta/explorations/skill-template-separation/README.md
+++ b/admin/services/meta/explorations/skill-template-separation/README.md
@@ -1,7 +1,7 @@
 # Skill-Template Separation
 
 **Purpose:** Explore the structural separation of skills/commands/agents from templates, and the downstream question of what templates should actually contain  
-**Status:** 🟠 In Progress  
+**Status:** ✅ Promoted to feature  
 **Created:** 2026-05-06
 
 ---
@@ -10,16 +10,31 @@
 
 - **[Exploration](exploration.md)** — Themes, questions, spike assessment
 - **[Research Topics](research-topics.md)** — Prioritized questions for investigation
+- **[Feature (promoted)](../../features/skill-template-separation/)** — Research proceeds here
+- **[Outcomes](outcomes.md)** — Promotion record
+
+---
+
+## 🏢 Service Ownership
+
+| Concern | Owner | Rationale |
+|---------|-------|-----------|
+| This exploration (identity shift, template minimalism, initiative naming) | **meta** | Structural evolution of dev-infra's identity and organization |
+| Skill substrate (configurable path roots, per-repo profiles) | **ai-workflow** | How skills resolve paths and configure themselves — operational tooling |
+| Template products (what ships in `templates/`) | **template-generation** | Product packaging — consumes the decisions made here |
+
+The exploration lives in `meta` because it's about what dev-infra *is*. The implementation of enabling substrate (Theme 3) is dispatched to `ai-workflow`. Template changes resulting from minimalism decisions go to `template-generation`.
 
 ---
 
 ## 🔗 Related
 
 - **Prior art:** `admin/services/meta/features/global-command-distribution/` (December 2025, stalled at requirements/research — superseded by this exploration's broader framing)
-- **Substrate:** `admin/planning/opportunities/internal/dev-infra/improvements/per-repo-skill-profile-unified.md` (⚠️ Unsorted)
-- **Substrate:** `admin/planning/opportunities/internal/dev-infra/improvements/skills-path-roots-configurable.md` (⚠️ Unsorted)
-- **Learning:** `admin/planning/opportunities/internal/dev-infra/learnings/skills-shape-not-location.md` (⚠️ Unsorted)
+- **Substrate (ai-workflow):** `admin/planning/opportunities/internal/dev-infra/improvements/per-repo-skill-profile-unified.md` (⚠️ Unsorted → ai-workflow backlog)
+- **Substrate (ai-workflow):** `admin/planning/opportunities/internal/dev-infra/improvements/skills-path-roots-configurable.md` (⚠️ Unsorted → ai-workflow backlog)
+- **Learning:** `admin/planning/opportunities/internal/dev-infra/learnings/skills-shape-not-location.md` (⚠️ Unsorted → ai-workflow backlog)
 - **Identity:** `admin/services/meta/features/dev-infra-identity-and-focus/` (ADR-001: "template factory")
+- **Informing:** See `📎 Related Int-Opps and Prior Art` section in [exploration.md](exploration.md) for additional int-opps that feed into research
 
 ---
 

--- a/admin/services/meta/explorations/skill-template-separation/README.md
+++ b/admin/services/meta/explorations/skill-template-separation/README.md
@@ -1,0 +1,26 @@
+# Skill-Template Separation
+
+**Purpose:** Explore the structural separation of skills/commands/agents from templates, and the downstream question of what templates should actually contain  
+**Status:** 🟠 In Progress  
+**Created:** 2026-05-06
+
+---
+
+## 📋 Quick Links
+
+- **[Exploration](exploration.md)** — Themes, questions, spike assessment
+- **[Research Topics](research-topics.md)** — Prioritized questions for investigation
+
+---
+
+## 🔗 Related
+
+- **Prior art:** `admin/services/meta/features/global-command-distribution/` (December 2025, stalled at requirements/research — superseded by this exploration's broader framing)
+- **Substrate:** `admin/planning/opportunities/internal/dev-infra/improvements/per-repo-skill-profile-unified.md` (⚠️ Unsorted)
+- **Substrate:** `admin/planning/opportunities/internal/dev-infra/improvements/skills-path-roots-configurable.md` (⚠️ Unsorted)
+- **Learning:** `admin/planning/opportunities/internal/dev-infra/learnings/skills-shape-not-location.md` (⚠️ Unsorted)
+- **Identity:** `admin/services/meta/features/dev-infra-identity-and-focus/` (ADR-001: "template factory")
+
+---
+
+**Last Updated:** 2026-05-06

--- a/admin/services/meta/explorations/skill-template-separation/exploration.md
+++ b/admin/services/meta/explorations/skill-template-separation/exploration.md
@@ -1,0 +1,92 @@
+# Exploration: Skill-Template Separation
+
+**Created:** 2026-05-06
+
+---
+
+## 🎯 What We're Exploring
+
+Dev-infra's skills, commands, and agents have been installed globally (`~/.cursor/skills/`, `~/.cursor/commands/`, `~/.cursor/agents/`) and run across all projects — including non-dev-infra work repos. Meanwhile, the templates (`templates/standard-project/`, `templates/learning-project/`) are products shipped to other people's projects. These two concerns have different audiences, different release cadences, and different evolution pressures. The authoritative source for skills currently lives inside the template tree, but that's wrong — the template tree is a snapshot destination, not an authoring location. We need to separate them and, in the process, rethink what templates should actually contain.
+
+---
+
+## 🔍 Themes
+
+### Theme 1: Skills/Commands/Agents as Their Own Concern
+
+- Skills, commands, and agents are now global installs (`~/.cursor/skills/`, `~/.cursor/commands/`, `~/.cursor/agents/`) that run in any repo — they're personal operational tooling, not template products
+- The authoritative copies currently live in `templates/standard-project/.claude/skills/` and `templates/standard-project/.cursor/commands/`, but the global installs have already diverged (skills like `ticket-intake`, `update-pr-description`, `apprentice-eod`, and agents like `group-cycle-work.agent.md` exist only globally)
+- The `git status` on develop shows mass deletions of `.claude/skills/` and `.cursor/commands/` — evidence that the working tree already treats these as global, not template-local
+- Skills evolve continuously; templates get released with version numbers. Forcing both into the same release cycle creates friction
+- The dependency direction should be: global installs are authority → templates get a snapshot at release time (Model A from the `/discuss` session)
+- This is the resolution of the `global-command-distribution` feature (December 2025), which stalled at requirements/research because it didn't have the broader framing
+
+### Theme 2: Template Minimalism
+
+- Templates currently assume backend/frontend structure, full thinking-pipeline docs infrastructure, CI/CD with template-sync, hub-and-spoke documentation — that's overwhelming as a day-one scaffold
+- Even in the author's own projects, the backend/frontend split was dropped entirely — evidence that the opinion doesn't generalize
+- A user looking at the scaffold has to understand what the templates are doing before they can do their own work — the template is noise until it's learned
+- The alternative framing: templates should be just enough for lifecycle management (`proj-cli`/`work-prod`) and a safe "landing site" for AI agents to do their work in
+- This dramatically reduces the docs therein — the template becomes a "project contract" (manifest, agent scratch path, git hygiene) rather than a "comprehensive scaffold"
+- Everything else (directory structure, docs infrastructure, the full thinking pipeline) becomes opt-in layers added as needed, not pre-installed on day one
+
+### Theme 3: Per-Repo Skill Profile as the Enabling Substrate
+
+- Skills today hardcode path-detection lists (three artifact roots for `pre-commit-review`, dev-infra-shaped paths for `write-plan`). This breaks when a skill runs in a repo the author didn't anticipate
+- The `research` skill stopped in `~/apprentice-notes/` because it was too opinionated about repo structure — it should have said "I'm going to set up here, if this is not cool, tell me where I should go"
+- The per-repo profile concept (`~/.cursor/repos/<slug>.yaml`) would let skills ask "where do things go in this repo?" and get a per-repo answer without hardcoding
+- The profile is the substrate that makes both separation (skills work anywhere) and template minimalism (the template doesn't pre-build structure; the profile tells skills where to create it on demand) possible
+- The `ticket-intake/repos/<slug>.yaml` precedent already works for branch/commit conventions — the generalization extends it to artifact roots, plan roots, scratch paths
+- Without this substrate, skills either need detection heuristics (fragile) or the template must pre-build all structure (heavy)
+
+### Theme 4: Initiative Naming and Roadmap Artifact
+
+- "Feature" as a concept under `meta/` feels wrong because features imply product deliverables to users; meta work is structural evolution of the project itself
+- "Initiative" is a better fit — signals coordinated internal work that reshapes how we operate, without borrowing product-delivery connotations
+- A roadmap artifact should be **service-level** (e.g., `admin/services/meta/roadmap.md`), not nested under planning — it connects the initiatives into a sequenced whole
+- Planning itself goes deeper, at the initiative/feature level — the roadmap is the thing that says "here's the order, here are the dependencies between initiatives"
+- The roadmap gets produced at the end of the thinking pipeline for this exploration (after research and decisions), not at the beginning
+
+### Theme 5: The `global-command-distribution` Feature — Absorb or Reference?
+
+- The December 2025 feature under `admin/services/meta/features/global-command-distribution/` has requirements and research (FR-1 through FR-5, NFR-1/2, constraints C-1/C-2) that are directly relevant
+- Some of those requirements still apply (install commands globally, version tracking, update mechanism)
+- Some are outdated (the feature assumed templates were the authority; reality has since drifted to global-first)
+- The exploration should absorb the relevant requirements into its themes rather than leaving a stale feature alongside the new exploration
+- The feature's research topics (installation methods, project-vs-global scope, version management, update strategy) are still useful prior art for research
+
+---
+
+## ❓ Key Questions
+
+1. What's the minimum "project contract" that `proj-cli`/`work-prod` and agents need to manage a project's lifecycle? (i.e., what *must* be in the minimal template?)
+2. Should the per-repo skill profile live at `~/.cursor/repos/<slug>.yaml` (top-level), `~/.cursor/profiles/<slug>.yaml`, or `~/.cursor/skills/_shared/repos/<slug>.yaml`? What's the lookup convention?
+3. Does dev-infra continue to own the skill corpus (just with global installs as the primary location), or do skills become a separate project/repo?
+4. What happens to the `templates/standard-project/.claude/skills/` copies — do they stay as release snapshots, or do templates stop bundling skills entirely (relying on global installs)?
+5. If templates become minimal, what's the migration path for existing projects that already generated from the comprehensive templates?
+6. What's the right naming for meta-level work units — "initiative"? — and does the directory structure change from `features/` to `initiatives/`?
+7. How does the `global-command-distribution` feature's research fold into this exploration? Absorb into research topics, or mark as superseded and reference?
+
+---
+
+## 🧪 Spike Determination
+
+| Topic | Risk Level | Spike? | Rationale |
+|-------|------------|--------|-----------|
+| Skills as their own concern | LOW | No | Already de facto done — the global installs exist. This is catching up documentation and release process to reality. |
+| Template minimalism | MEDIUM-HIGH | Consider | Major product redefinition. What "minimum viable template" looks like is genuinely unclear. A spike creating a minimal template and testing it on a real project would surface what's actually needed. |
+| Per-repo skill profile | MEDIUM | No | The shape is already sketched (`per-repo-skill-profile-unified.md`). Research is sufficient — no hard-to-reverse decisions. |
+| Initiative naming / roadmap | LOW | No | Naming is a decision, not a risk. Can be made directly after research. |
+| Absorbing global-command-distribution | LOW | No | Reading existing requirements and deciding what's still relevant. Pure desk work. |
+
+**Risk framework:** HIGH = spike first (hard to pivot), MEDIUM-HIGH = consider spike, MEDIUM/LOW = research only.
+
+---
+
+## 🚀 Next Steps
+
+Review this exploration, then:
+- `/explore-amend` to add new themes from downstream discovery
+- `/research --from-explore skill-template-separation` to investigate open questions
+- The template-minimalism theme (MEDIUM-HIGH risk) may benefit from a `/spike` before committing to a design — test the "minimal template" concept on a real project
+- Proceed directly to the skill-separation initiative if the exploration is sufficient (it's LOW risk and de facto already done)

--- a/admin/services/meta/explorations/skill-template-separation/exploration.md
+++ b/admin/services/meta/explorations/skill-template-separation/exploration.md
@@ -30,7 +30,7 @@ Dev-infra's skills, commands, and agents have been installed globally (`~/.curso
 - This dramatically reduces the docs therein — the template becomes a "project contract" (manifest, agent scratch path, git hygiene) rather than a "comprehensive scaffold"
 - Everything else (directory structure, docs infrastructure, the full thinking pipeline) becomes opt-in layers added as needed, not pre-installed on day one
 
-### Theme 3: Per-Repo Skill Profile as the Enabling Substrate
+### Theme 3: Per-Repo Skill Profile as the Enabling Substrate *(ai-workflow owns implementation; meta depends on it)*
 
 - Skills today hardcode path-detection lists (three artifact roots for `pre-commit-review`, dev-infra-shaped paths for `write-plan`). This breaks when a skill runs in a repo the author didn't anticipate
 - The `research` skill stopped in `~/apprentice-notes/` because it was too opinionated about repo structure — it should have said "I'm going to set up here, if this is not cool, tell me where I should go"
@@ -38,6 +38,7 @@ Dev-infra's skills, commands, and agents have been installed globally (`~/.curso
 - The profile is the substrate that makes both separation (skills work anywhere) and template minimalism (the template doesn't pre-build structure; the profile tells skills where to create it on demand) possible
 - The `ticket-intake/repos/<slug>.yaml` precedent already works for branch/commit conventions — the generalization extends it to artifact roots, plan roots, scratch paths
 - Without this substrate, skills either need detection heuristics (fragile) or the template must pre-build all structure (heavy)
+- **Service boundary:** This theme's *implementation* belongs to the `ai-workflow` service (it's about how skills resolve paths). The meta exploration *depends on* it as an enabling substrate — the separation and template minimalism goals can't be fully realized until skills can work without hardcoded repo assumptions. The int-opp docs (`skills-path-roots-configurable.md`, `per-repo-skill-profile-unified.md`) will sort into ai-workflow's backlog once they get formal feature treatment
 
 ### Theme 4: Initiative Naming and Roadmap Artifact
 
@@ -80,6 +81,36 @@ Dev-infra's skills, commands, and agents have been installed globally (`~/.curso
 | Absorbing global-command-distribution | LOW | No | Reading existing requirements and deciding what's still relevant. Pure desk work. |
 
 **Risk framework:** HIGH = spike first (hard to pivot), MEDIUM-HIGH = consider spike, MEDIUM/LOW = research only.
+
+---
+
+## 📎 Related Explorations and Features
+
+**Directly connected (same problem space, different vantage points):**
+
+| Exploration/Feature | Service | Status | Connection to Skill-Template Separation |
+|---------------------|---------|--------|----------------------------------------|
+| **[Workflow Decoupling](../../../template-generation/explorations/workflow-decoupling/)** | template-generation | 🔴 Exploration | The *same problem* from the template-generation perspective. Themes 1–3 there (drift, velocity layers, command-vs-skill distinction) are the template-side of our Theme 1 and Theme 2. Its "Package Manager Question" (Theme 4) is the distribution mechanism we'll need once separation is decided. **Should be absorbed or cross-referenced as sibling.** |
+| **[Four-Arm Architecture](../../features/four-arm-architecture/)** | meta | ✅ Complete | Established ADR-001 (command distribution: dev-infra = source, dev-toolkit = distribution). Skill-template separation *extends* this: if skills/commands/agents are their own concern, the four-arm architecture gains a clearer "what ships where" story. The per-repo profile (Theme 3) is the substrate that makes ADR-003's "per-tool configuration" actually work for skills. |
+| **[proj-cli Focused Role](../proj-cli-focused-role/)** | meta | 🔴 Exploration | Defined proj-cli's scope as "lifecycle sync against templates." Template minimalism (Theme 2) directly changes *what proj-cli syncs* — a minimal template means proj-cli tracks a smaller, stabler surface. If templates stop bundling skills, proj-cli's scope narrows further. |
+| **[Worktree Feature Workflow](../worktree-feature-workflow/)** | meta | 🔴 Exploration | Self-contained feature branches with docs traveling on-branch. The `.scratch/` pattern from `group-cycle-work.agent.md` is a runtime instance of this principle — planning artifacts live in the workspace but don't commit to the repo. Separation enables this: skills know where to put things (profile), not where templates pre-built things. |
+
+**Implications:** The workflow-decoupling exploration in template-generation is essentially asking "how do we distribute what's being separated?" while skill-template-separation asks "what *is* the separation and what does a template become after?" They're two halves of the same initiative. Research should proceed jointly or at minimum cite each other's findings.
+
+---
+
+## 📎 Related Int-Opps and Prior Art
+
+**Directly enabling (ai-workflow substrate, depended on by this exploration):**
+- `admin/planning/opportunities/internal/dev-infra/improvements/skills-path-roots-configurable.md` — make path roots configurable in `pre-commit-review`, `commit`, `write-plan*` (HIGH priority)
+- `admin/planning/opportunities/internal/dev-infra/improvements/per-repo-skill-profile-unified.md` — unify per-repo config under single profile file (MEDIUM priority)
+- `admin/planning/opportunities/internal/dev-infra/learnings/skills-shape-not-location.md` — the principle underpinning Theme 3
+
+**Informing (independent int-opps, cite for research):**
+- `admin/planning/opportunities/internal/dev-infra/improvements/artifact-emission-strategy.md` — L0-L3 spectrum for skill artifact emission; Principles 1-4 directly inform Topic 1 (minimum viable project contract) and Template Minimalism (Theme 2). Its "Essential vs Incidental Artifacts" classification is useful for determining what *must* be in a template.
+- `admin/planning/opportunities/internal/dev-infra/improvements/feature-first-directory-structure.md` — already implemented (service-first structure), but its Capstone ("tool injection vs framework marriage") provides the framing for Template Minimalism: dev-infra should produce tools, not impose structure.
+- `admin/planning/opportunities/internal/dev-infra/improvements/skill-config-rendering.md` — Helm-style values for per-platform rendering (Cursor vs Claude Code). Adjacent to Theme 1 (skills as their own concern) because platform distribution is part of how skills get shipped.
+- `admin/planning/opportunities/internal/dev-infra/improvements/skill-toolbelt-colocated-scripts.md` — co-located scripts travel with skills; relevant to Theme 1 because scripts are part of the skill surface that separates from templates.
 
 ---
 

--- a/admin/services/meta/explorations/skill-template-separation/outcomes.md
+++ b/admin/services/meta/explorations/skill-template-separation/outcomes.md
@@ -1,0 +1,10 @@
+# Exploration Outcomes — skill-template-separation
+
+**Status:** ✅ Promoted to feature
+**Created:** 2026-05-06
+
+## What This Exploration Produced
+
+Promoted to feature: [../../features/skill-template-separation/](../../features/skill-template-separation/)
+
+Exploration artifacts (exploration.md, research-topics.md) remain here as reference. Research proceeds under the feature directory.

--- a/admin/services/meta/explorations/skill-template-separation/research-topics.md
+++ b/admin/services/meta/explorations/skill-template-separation/research-topics.md
@@ -1,0 +1,57 @@
+# Research Topics — Skill-Template Separation
+
+**Created:** 2026-05-06
+
+---
+
+## 📋 Topics Identified
+
+### Topic 1: Minimum Viable Project Contract
+
+**Question:** What's the minimum set of files/structure that `proj-cli`/`work-prod` and AI agents need to manage a project's lifecycle — i.e., what must be in the minimal template?
+**Priority:** High
+**Context:** If templates become minimal, we need to know the floor — below which tooling can't function. This determines the boundary between "template provides" and "added on demand."
+
+### Topic 2: Per-Repo Profile Location and Schema
+
+**Question:** Where should the unified per-repo skill profile live, what's its schema, and how do skills look it up?
+**Priority:** High
+**Context:** The per-repo profile is the substrate that enables skills to work in any repo without hardcoded path assumptions. Getting the location and schema right at v1 matters because migration is costly later.
+
+### Topic 3: Skill Corpus Ownership Model
+
+**Question:** Does dev-infra continue to own the skill corpus (global installs as primary, dev-infra as the repo), or do skills become a separate project?
+**Priority:** Medium
+**Context:** If skills stay in dev-infra, the separation is internal (different release cadence, same repo). If skills split out, there's a real coordination cost but cleaner boundaries. The answer depends on whether other people will consume these skills or they stay personal.
+
+### Topic 4: Template Skill Bundling Strategy
+
+**Question:** After separation, do templates still bundle a subset of skills (as release snapshots), or do they rely entirely on global installs and just document which skills they expect?
+**Priority:** Medium
+**Context:** Bundling means templates are self-contained (a generated project works without global installs). Relying on global installs means templates are lighter but depend on the user having set up their environment. Different tradeoffs for different audiences.
+
+### Topic 5: Migration Path for Existing Projects
+
+**Question:** What happens to projects already generated from the comprehensive template? Do they get a migration command, or do they just keep their existing structure indefinitely?
+**Priority:** Low
+**Context:** Existing projects (PiHole-DNS, support-shark, etc.) have the full scaffold. If templates slim down, these projects don't automatically slim — they'd need either a migration tool or a "you're fine, just ignore the extra structure" answer.
+
+### Topic 6: `global-command-distribution` Requirements Audit
+
+**Question:** Which requirements from the December 2025 `global-command-distribution` feature still apply, which are outdated, and which should be absorbed into this exploration's research?
+**Priority:** Medium
+**Context:** That feature has 5 FRs, 2 NFRs, and 2 constraints already researched. Some (FR-1: install globally) are already done. Others (FR-3: version tracking) may still be relevant. Auditing avoids duplicating work.
+
+### Topic 7: Meta Work-Unit Naming
+
+**Question:** Should meta-level work units be called "initiatives" (or something else), and should the directory structure change from `features/` to reflect this?
+**Priority:** Low
+**Context:** "Feature" implies product delivery; meta work is structural. Naming matters for how work feels and gets communicated, but it's a decision to make, not a research problem. Quick resolution once other topics are clearer.
+
+---
+
+## 🚀 Next Steps
+
+Use `/research --from-explore skill-template-separation` to investigate these questions.
+
+Topics 1 and 2 are the highest priority — they determine the shape of both the minimal template and the skill substrate. Topic 6 is housekeeping that should happen early to avoid duplicating existing research.

--- a/admin/services/meta/features/readme-narrative/planning/implementation-plan.md
+++ b/admin/services/meta/features/readme-narrative/planning/implementation-plan.md
@@ -26,7 +26,7 @@ tasks_files:
 
 ## 📋 Overview
 
-Dev-infra's README currently reads as a product spec sheet — it describes what the project does and how to use it, but provides no context for why it exists, how it evolved, or what it has produced. Research on 2026 narrative-driven README conventions (Finding 1) and self-assessment identified that the README lacks an origin section (Finding 2), underselling a 7-month, 1,100+ commit project with 14 ADRs and multiple downstream production projects (pi-hole DNS, proj-cli, OurFileServer). This plan adds narrative context, restructures the README to lead with purpose over mechanics, and reconciles the untouched start.txt.
+Dev-infra's README currently reads as a product spec sheet — it describes what the project does and how to use it, but provides no context for why it exists, how it evolved, or what it has produced. Research on 2026 narrative-driven README conventions (Finding 1) and self-assessment identified that the README lacks an origin section (Finding 2), underselling a 7-month, 1,100+ commit project with 14 ADRs and multiple downstream production projects (pihole-dns, proj-cli, ourfileserver). This plan adds narrative context, restructures the README to lead with purpose over mechanics, and reconciles the untouched start.txt.
 
 **Key Changes:**
 - Add origin/narrative section communicating why dev-infra exists, the identity pivot, and downstream lineage

--- a/admin/services/meta/features/readme-narrative/planning/implementation-plan.md
+++ b/admin/services/meta/features/readme-narrative/planning/implementation-plan.md
@@ -49,7 +49,7 @@ Dev-infra's README currently reads as a product spec sheet — it describes what
 ## 📝 Implementation Plan
 
 ### Origin Narrative Content
-- [ ] Task 1: Draft origin section — the problem that motivated dev-infra
+- [x] Task 1: Draft origin section — the problem that motivated dev-infra
 - [ ] Task 2: Write identity pivot narrative — lab/factory/reference tension and ADR-001 resolution
 - [ ] Task 3: Write downstream lineage section — projects produced by dev-infra patterns
 

--- a/admin/services/meta/features/readme-narrative/planning/implementation-plan.md
+++ b/admin/services/meta/features/readme-narrative/planning/implementation-plan.md
@@ -1,0 +1,88 @@
+---
+task_count: 9
+groups:
+  - name: "Origin Narrative Content"
+    file: "tasks/01-origin-narrative-content.md"
+    tasks: [1, 2, 3]
+  - name: "README Restructure"
+    file: "tasks/02-readme-restructure.md"
+    tasks: [4, 5, 6, 7]
+  - name: "Start.txt Reconciliation"
+    file: "tasks/03-start-txt-reconciliation.md"
+    tasks: [8, 9]
+tasks_files:
+  - "tasks/01-origin-narrative-content.md"
+  - "tasks/02-readme-restructure.md"
+  - "tasks/03-start-txt-reconciliation.md"
+---
+# Implementation Plan — README Narrative
+
+**Status:** 🟠 In Progress
+**Created:** 2026-05-14
+**Last Updated:** 2026-05-14
+**Source:** Discussion artifacts + research on narrative-driven READMEs + ADR-001 (project identity) + existing README.md + start.txt
+
+---
+
+## 📋 Overview
+
+Dev-infra's README currently reads as a product spec sheet — it describes what the project does and how to use it, but provides no context for why it exists, how it evolved, or what it has produced. Research on 2026 narrative-driven README conventions (Finding 1) and self-assessment identified that the README lacks an origin section (Finding 2), underselling a 7-month, 1,100+ commit project with 14 ADRs and multiple downstream production projects (pi-hole DNS, proj-cli, OurFileServer). This plan adds narrative context, restructures the README to lead with purpose over mechanics, and reconciles the untouched start.txt.
+
+**Key Changes:**
+- Add origin/narrative section communicating why dev-infra exists, the identity pivot, and downstream lineage
+- Restructure README to follow 2026 conventions: origin story first, technical details secondary
+- Address staleness (dates, version references, broken link placeholders)
+- Fill in start.txt with actual project initialization context
+
+---
+
+## 🎯 Goals
+
+1. **Communicate the project's nature** — A reader should understand that dev-infra is a living system that produces other systems, not a weekend scaffold generator
+2. **Surface the origin and identity pivot** — The lab-to-factory decision (ADR-001) shows project maturity that the current README hides
+3. **Document downstream lineage** — Real projects running on dev-infra patterns are the proof that the templates work
+4. **Follow 2026 README conventions** — Origin story first, technical details collapsible/secondary, research methodology over marketing claims
+5. **Eliminate staleness** — Version refs, dates, and placeholder links should reflect current state
+
+---
+
+## 📝 Implementation Plan
+
+### Origin Narrative Content
+- [ ] Task 1: Draft origin section — the problem that motivated dev-infra
+- [ ] Task 2: Write identity pivot narrative — lab/factory/reference tension and ADR-001 resolution
+- [ ] Task 3: Write downstream lineage section — projects produced by dev-infra patterns
+
+### README Restructure
+- [ ] Task 4: Reorder README sections — origin/narrative before Quick Start
+- [ ] Task 5: Consolidate redundant sections and reduce emoji-header noise
+- [ ] Task 6: Update stale references — version numbers, dates, placeholder links
+- [ ] Task 7: Make technical details secondary — collapsible or lower-priority positioning
+
+### Start.txt Reconciliation
+- [ ] Task 8: Fill in start.txt with actual dev-infra project context
+- [ ] Task 9: Review start.txt against README origin section for consistency
+
+---
+
+## ✅ Definition of Done
+
+- [ ] README has an origin/narrative section before Quick Start
+- [ ] A reader can understand why this project exists without scrolling to technical details
+- [ ] Downstream projects are named and their relationship to dev-infra is clear
+- [ ] No stale version numbers, dates, or broken placeholder links
+- [ ] start.txt reflects actual project context, not template placeholders
+- [ ] Commit history shows clean `docs(readme-narrative):` scoping
+
+---
+
+## 🔗 Related
+
+- [ADR-001: Project Identity](../../dev-infra-identity-and-focus/decisions/adr-001-project-identity.md) — the identity pivot from lab+factory+reference to template factory
+- [Discussion artifacts](.) — this plan sourced from `/discuss` session on narrative-driven READMEs
+- Research Finding 1: Narrative-driven READMEs as 2026 convention (Grinta-Agent, Clarté, BlackRoad, Lumen)
+- Research Finding 2: dev-infra README currently has no origin section
+
+---
+
+**Last Updated:** 2026-05-14

--- a/admin/services/meta/features/readme-narrative/planning/implementation-plan.md
+++ b/admin/services/meta/features/readme-narrative/planning/implementation-plan.md
@@ -51,7 +51,7 @@ Dev-infra's README currently reads as a product spec sheet — it describes what
 ### Origin Narrative Content
 - [x] Task 1: Draft origin section — the problem that motivated dev-infra
 - [x] Task 2: Write identity pivot narrative — lab/factory/reference tension and ADR-001 resolution
-- [ ] Task 3: Write downstream lineage section — projects produced by dev-infra patterns
+- [x] Task 3: Write downstream lineage section — projects produced by dev-infra patterns
 
 ### README Restructure
 - [ ] Task 4: Reorder README sections — origin/narrative before Quick Start

--- a/admin/services/meta/features/readme-narrative/planning/implementation-plan.md
+++ b/admin/services/meta/features/readme-narrative/planning/implementation-plan.md
@@ -50,7 +50,7 @@ Dev-infra's README currently reads as a product spec sheet — it describes what
 
 ### Origin Narrative Content
 - [x] Task 1: Draft origin section — the problem that motivated dev-infra
-- [ ] Task 2: Write identity pivot narrative — lab/factory/reference tension and ADR-001 resolution
+- [x] Task 2: Write identity pivot narrative — lab/factory/reference tension and ADR-001 resolution
 - [ ] Task 3: Write downstream lineage section — projects produced by dev-infra patterns
 
 ### README Restructure

--- a/admin/services/meta/features/readme-narrative/planning/status-and-next-steps.md
+++ b/admin/services/meta/features/readme-narrative/planning/status-and-next-steps.md
@@ -7,11 +7,11 @@
 
 ## 📊 Progress Summary
 
-**Overall:** 1/9 tasks complete
+**Overall:** 2/9 tasks complete
 
 | Group | Status | Progress | Notes |
 |-------|--------|----------|-------|
-| Origin Narrative Content | 🟠 In Progress | 1/3 tasks | |
+| Origin Narrative Content | 🟠 In Progress | 2/3 tasks | |
 | README Restructure | 🔴 Not Started | 0/4 tasks | |
 | Start.txt Reconciliation | 🔴 Not Started | 0/2 tasks | |
 

--- a/admin/services/meta/features/readme-narrative/planning/status-and-next-steps.md
+++ b/admin/services/meta/features/readme-narrative/planning/status-and-next-steps.md
@@ -1,6 +1,6 @@
 # Status & Next Steps — README Narrative
 
-**Status:** 🔴 Not Started
+**Status:** 🟠 In Progress
 **Last Updated:** 2026-05-14
 
 ---
@@ -19,9 +19,9 @@
 
 ## 🚀 Next Steps
 
-1. Review scaffolding — verify group/task breakdown matches discussion intent.
-2. Expand groups — run write-plan **Expand** for group 1 (Origin Narrative Content).
-3. Start implementation — begin with origin section drafting.
+1. Expand and implement Group 2 — README Restructure (Tasks 4–7).
+2. Expand and implement Group 3 — Start.txt Reconciliation (Tasks 8–9).
+3. Merge to develop when all groups complete.
 
 ---
 

--- a/admin/services/meta/features/readme-narrative/planning/status-and-next-steps.md
+++ b/admin/services/meta/features/readme-narrative/planning/status-and-next-steps.md
@@ -7,11 +7,11 @@
 
 ## 📊 Progress Summary
 
-**Overall:** 0/9 tasks complete
+**Overall:** 1/9 tasks complete
 
 | Group | Status | Progress | Notes |
 |-------|--------|----------|-------|
-| Origin Narrative Content | 🟠 In Progress | 0/3 tasks | |
+| Origin Narrative Content | 🟠 In Progress | 1/3 tasks | |
 | README Restructure | 🔴 Not Started | 0/4 tasks | |
 | Start.txt Reconciliation | 🔴 Not Started | 0/2 tasks | |
 

--- a/admin/services/meta/features/readme-narrative/planning/status-and-next-steps.md
+++ b/admin/services/meta/features/readme-narrative/planning/status-and-next-steps.md
@@ -7,11 +7,11 @@
 
 ## 📊 Progress Summary
 
-**Overall:** 2/9 tasks complete
+**Overall:** 3/9 tasks complete
 
 | Group | Status | Progress | Notes |
 |-------|--------|----------|-------|
-| Origin Narrative Content | 🟠 In Progress | 2/3 tasks | |
+| Origin Narrative Content | ✅ Complete | 3/3 tasks | |
 | README Restructure | 🔴 Not Started | 0/4 tasks | |
 | Start.txt Reconciliation | 🔴 Not Started | 0/2 tasks | |
 

--- a/admin/services/meta/features/readme-narrative/planning/status-and-next-steps.md
+++ b/admin/services/meta/features/readme-narrative/planning/status-and-next-steps.md
@@ -1,0 +1,37 @@
+# Status & Next Steps — README Narrative
+
+**Status:** 🔴 Not Started
+**Last Updated:** 2026-05-14
+
+---
+
+## 📊 Progress Summary
+
+**Overall:** 0/9 tasks complete
+
+| Group | Status | Progress | Notes |
+|-------|--------|----------|-------|
+| Origin Narrative Content | 🟠 In Progress | 0/3 tasks | |
+| README Restructure | 🔴 Not Started | 0/4 tasks | |
+| Start.txt Reconciliation | 🔴 Not Started | 0/2 tasks | |
+
+---
+
+## 🚀 Next Steps
+
+1. Review scaffolding — verify group/task breakdown matches discussion intent.
+2. Expand groups — run write-plan **Expand** for group 1 (Origin Narrative Content).
+3. Start implementation — begin with origin section drafting.
+
+---
+
+## 📝 Notes
+
+- Plan generated from `/discuss` session artifacts on 2026-05-14.
+- Input mode: `from_artifacts` (discussion + research findings + ADR-001 + README.md + start.txt).
+- Planning root: `admin/services/meta/features/readme-narrative/planning/`.
+- This plan was scaffolded without a formal ADR or requirements doc; the discussion served as the design surface and the plan doubles as a lightweight requirements capture.
+
+---
+
+**Last Updated:** 2026-05-14

--- a/admin/services/meta/features/readme-narrative/planning/tasks/01-origin-narrative-content.md
+++ b/admin/services/meta/features/readme-narrative/planning/tasks/01-origin-narrative-content.md
@@ -15,7 +15,7 @@
   - Write the "why this exists" narrative: the pain of recreating project structures, the pattern recognition across pokehub/dev-toolkit/containers
   - Deliverable: Origin paragraph(s) ready for README insertion
 
-- [ ] Task 2: Write identity pivot narrative — lab/factory/reference tension and ADR-001 resolution
+- [x] Task 2: Write identity pivot narrative — lab/factory/reference tension and ADR-001 resolution
   - Distill ADR-001's core tension (organic growth into three roles) and resolution (template factory focus) into reader-facing prose
   - Deliverable: Identity section that communicates project maturity without requiring readers to find the ADR
 

--- a/admin/services/meta/features/readme-narrative/planning/tasks/01-origin-narrative-content.md
+++ b/admin/services/meta/features/readme-narrative/planning/tasks/01-origin-narrative-content.md
@@ -21,7 +21,7 @@
   - Deliverable: Identity section that communicates project maturity without requiring readers to find the ADR
 
 - [x] Task 3: Write downstream lineage section — projects produced by dev-infra patterns
-  - Name real downstream projects (pi-hole DNS, proj-cli, OurFileServer, etc.) and describe what dev-infra patterns they use
+  - Name real downstream projects (pihole-dns, proj-cli, ourfileserver, etc.) and describe what dev-infra patterns they use
   - Deliverable: Lineage section establishing dev-infra as a living system that produces production infrastructure
 
 ---

--- a/admin/services/meta/features/readme-narrative/planning/tasks/01-origin-narrative-content.md
+++ b/admin/services/meta/features/readme-narrative/planning/tasks/01-origin-narrative-content.md
@@ -11,7 +11,7 @@
 
 ## 📝 Tasks
 
-- [ ] Task 1: Draft origin section — the problem that motivated dev-infra
+- [x] Task 1: Draft origin section — the problem that motivated dev-infra
   - Write the "why this exists" narrative: the pain of recreating project structures, the pattern recognition across pokehub/dev-toolkit/containers
   - Deliverable: Origin paragraph(s) ready for README insertion
 

--- a/admin/services/meta/features/readme-narrative/planning/tasks/01-origin-narrative-content.md
+++ b/admin/services/meta/features/readme-narrative/planning/tasks/01-origin-narrative-content.md
@@ -2,7 +2,8 @@
 
 **Feature:** README Narrative
 **Group:** Origin Narrative Content
-**Status:** 🟠 In Progress
+**Status:** ✅ Complete
+**Completed:** 2026-05-14
 **Last Updated:** 2026-05-14
 
 > ⚠️ **Scaffolding only.** Run write-plan **Expand** on this group to generate detailed steps and acceptance criteria.
@@ -19,7 +20,7 @@
   - Distill ADR-001's core tension (organic growth into three roles) and resolution (template factory focus) into reader-facing prose
   - Deliverable: Identity section that communicates project maturity without requiring readers to find the ADR
 
-- [ ] Task 3: Write downstream lineage section — projects produced by dev-infra patterns
+- [x] Task 3: Write downstream lineage section — projects produced by dev-infra patterns
   - Name real downstream projects (pi-hole DNS, proj-cli, OurFileServer, etc.) and describe what dev-infra patterns they use
   - Deliverable: Lineage section establishing dev-infra as a living system that produces production infrastructure
 

--- a/admin/services/meta/features/readme-narrative/planning/tasks/01-origin-narrative-content.md
+++ b/admin/services/meta/features/readme-narrative/planning/tasks/01-origin-narrative-content.md
@@ -1,0 +1,52 @@
+# Origin Narrative Content
+
+**Feature:** README Narrative
+**Group:** Origin Narrative Content
+**Status:** 🟠 In Progress
+**Last Updated:** 2026-05-14
+
+> ⚠️ **Scaffolding only.** Run write-plan **Expand** on this group to generate detailed steps and acceptance criteria.
+
+---
+
+## 📝 Tasks
+
+- [ ] Task 1: Draft origin section — the problem that motivated dev-infra
+  - Write the "why this exists" narrative: the pain of recreating project structures, the pattern recognition across pokehub/dev-toolkit/containers
+  - Deliverable: Origin paragraph(s) ready for README insertion
+
+- [ ] Task 2: Write identity pivot narrative — lab/factory/reference tension and ADR-001 resolution
+  - Distill ADR-001's core tension (organic growth into three roles) and resolution (template factory focus) into reader-facing prose
+  - Deliverable: Identity section that communicates project maturity without requiring readers to find the ADR
+
+- [ ] Task 3: Write downstream lineage section — projects produced by dev-infra patterns
+  - Name real downstream projects (pi-hole DNS, proj-cli, OurFileServer, etc.) and describe what dev-infra patterns they use
+  - Deliverable: Lineage section establishing dev-infra as a living system that produces production infrastructure
+
+---
+
+## 🎯 Goals
+
+1. A reader understands why dev-infra exists after reading the origin section
+2. The identity pivot communicates maturity and intentional focus
+3. Downstream projects serve as proof that the patterns work in production
+
+---
+
+## ✅ Completion Criteria
+
+- [ ] Origin section answers "what problem did this solve for the person who built it"
+- [ ] Identity pivot is told as narrative, not as a link to an ADR
+- [ ] At least 3 downstream projects named with their relationship to dev-infra patterns
+- [ ] Tone matches the narrative skill's contract: "as if explaining to a thoughtful colleague"
+
+---
+
+## 🔗 Dependencies
+
+- ADR-001 content (already read; no blocking dependency)
+- User input on origin story details and downstream project specifics
+
+---
+
+**Last Updated:** 2026-05-14

--- a/admin/services/meta/features/readme-narrative/planning/tasks/02-readme-restructure.md
+++ b/admin/services/meta/features/readme-narrative/planning/tasks/02-readme-restructure.md
@@ -1,0 +1,56 @@
+# README Restructure
+
+**Feature:** README Narrative
+**Group:** README Restructure
+**Status:** 🔴 Scaffolding (needs expansion)
+**Last Updated:** 2026-05-14
+
+> ⚠️ **Scaffolding only.** Run write-plan **Expand** on this group to generate detailed steps and acceptance criteria.
+
+---
+
+## 📝 Tasks
+
+- [ ] Task 4: Reorder README sections — origin/narrative before Quick Start
+  - Move or insert origin content above the Quick Start section; current structure jumps from badges to installation
+  - Deliverable: README leads with purpose and context before mechanics
+
+- [ ] Task 5: Consolidate redundant sections and reduce emoji-header noise
+  - Current README has duplicate "Getting Started" (lines 53 and 213), redundant "Development" section that restates project structure, and heavy emoji usage that reads as filler
+  - Deliverable: Leaner README with no duplicated content
+
+- [ ] Task 6: Update stale references — version numbers, dates, placeholder links
+  - Version references (v0.6.0 in curl commands, v0.7.0-dev in header), last-updated date (2025-12-18), placeholder links ([issues-url], [discussions-url]), template statistics counts
+  - Deliverable: All references reflect current project state
+
+- [ ] Task 7: Make technical details secondary — collapsible or lower-priority positioning
+  - Template structures, technology stack, statistics, and use cases sections currently dominate; consider collapsible details or moving below fold
+  - Deliverable: Technical reference material accessible but not primary
+
+---
+
+## 🎯 Goals
+
+1. README follows 2026 convention: origin story first, technical details secondary
+2. No redundant sections or stale information
+3. Reader encounters purpose before instructions
+
+---
+
+## ✅ Completion Criteria
+
+- [ ] Origin/narrative section appears before Quick Start
+- [ ] No duplicate Getting Started / Quick Start sections
+- [ ] All version references match current project state
+- [ ] No placeholder links ([issues-url], [discussions-url])
+- [ ] Technical details are accessible but subordinate to narrative
+
+---
+
+## 🔗 Dependencies
+
+- Group 1 (Origin Narrative Content) should be drafted first so restructure can place it correctly
+
+---
+
+**Last Updated:** 2026-05-14

--- a/admin/services/meta/features/readme-narrative/planning/tasks/03-start-txt-reconciliation.md
+++ b/admin/services/meta/features/readme-narrative/planning/tasks/03-start-txt-reconciliation.md
@@ -1,0 +1,46 @@
+# Start.txt Reconciliation
+
+**Feature:** README Narrative
+**Group:** Start.txt Reconciliation
+**Status:** 🔴 Scaffolding (needs expansion)
+**Last Updated:** 2026-05-14
+
+> ⚠️ **Scaffolding only.** Run write-plan **Expand** on this group to generate detailed steps and acceptance criteria.
+
+---
+
+## 📝 Tasks
+
+- [ ] Task 8: Fill in start.txt with actual dev-infra project context
+  - The file has been untouched since the initial commit (2025-10-22) with template placeholders; fill in Problem Statement, Scope, and preferences that reflect dev-infra's actual configuration
+  - Deliverable: start.txt contains real project initialization context
+
+- [ ] Task 9: Review start.txt against README origin section for consistency
+  - Ensure start.txt's problem statement aligns with the origin narrative written in Group 1; these are two views of the same story (start.txt for project context, README for external audience)
+  - Deliverable: Both documents tell a consistent story with audience-appropriate framing
+
+---
+
+## 🎯 Goals
+
+1. start.txt serves its intended purpose as project initialization context
+2. Internal (start.txt) and external (README) origin stories are consistent
+
+---
+
+## ✅ Completion Criteria
+
+- [ ] start.txt Problem Statement filled with actual dev-infra motivation
+- [ ] start.txt Scope reflects current project boundaries
+- [ ] Preferences checkboxes reflect actual dev-infra configuration
+- [ ] No contradictions between start.txt and README origin section
+
+---
+
+## 🔗 Dependencies
+
+- Group 1 (Origin Narrative Content) should be complete for consistency review in Task 9
+
+---
+
+**Last Updated:** 2026-05-14

--- a/admin/services/meta/features/skill-template-separation/README.md
+++ b/admin/services/meta/features/skill-template-separation/README.md
@@ -1,0 +1,23 @@
+# skill-template-separation
+
+**Purpose:** Separate skills/commands/agents from templates as independent concerns, redefine what templates contain, establish per-repo skill profile as enabling substrate
+**Status:** 🟠 In Progress — Research
+**Created:** 2026-05-06
+
+---
+
+## Phase Directories
+
+- **[research/](research/)** — 7 topics investigating template minimalism, profile schema, ownership model, bundling strategy, migration, requirements audit, and naming
+
+## Provenance
+
+Promoted from service-level exploration: [../../explorations/skill-template-separation/](../../explorations/skill-template-separation/)
+
+## Service Ownership
+
+| Concern | Owner | Rationale |
+|---------|-------|-----------|
+| This feature (identity shift, template minimalism, initiative naming) | **meta** | Structural evolution of dev-infra's identity and organization |
+| Skill substrate (configurable path roots, per-repo profiles) | **ai-workflow** | How skills resolve paths and configure themselves — operational tooling |
+| Template products (what ships in `templates/`) | **template-generation** | Product packaging — consumes the decisions made here |

--- a/admin/services/meta/features/skill-template-separation/research/README.md
+++ b/admin/services/meta/features/skill-template-separation/research/README.md
@@ -19,7 +19,7 @@
 
 | # | Topic | File | Priority | Status |
 |---|-------|------|----------|--------|
-| 1 | Minimum Viable Project Contract | [research-minimum-viable-project-contract.md](research-minimum-viable-project-contract.md) | High | 🔴 Not Started |
+| 1 | Minimum Viable Project Contract | [research-minimum-viable-project-contract.md](research-minimum-viable-project-contract.md) | High | ✅ Complete |
 | 2 | Per-Repo Profile Location and Schema | [research-per-repo-profile-location-and-schema.md](research-per-repo-profile-location-and-schema.md) | High | 🔴 Not Started |
 | 3 | Skill Corpus Ownership Model | [research-skill-corpus-ownership-model.md](research-skill-corpus-ownership-model.md) | Medium | 🔴 Not Started |
 | 4 | Template Skill Bundling Strategy | [research-template-skill-bundling-strategy.md](research-template-skill-bundling-strategy.md) | Medium | 🔴 Not Started |

--- a/admin/services/meta/features/skill-template-separation/research/README.md
+++ b/admin/services/meta/features/skill-template-separation/research/README.md
@@ -1,0 +1,48 @@
+# Research — Skill-Template Separation
+
+**Purpose:** Investigate 7 topics to determine how skills/commands/agents separate from templates, what templates become after separation, and what substrate enables both
+**Status:** 🔴 Research
+**Created:** 2026-05-06
+**Last Updated:** 2026-05-06
+
+---
+
+## Quick Links
+
+- [Research Summary](research-summary.md) — cross-topic rollup (populated after conduct)
+- [Requirements](requirements.md) — FR / NFR / constraints extracted from findings
+- **Exploration source:** [../../explorations/skill-template-separation/](../../explorations/skill-template-separation/)
+
+---
+
+## Research Status
+
+| # | Topic | File | Priority | Status |
+|---|-------|------|----------|--------|
+| 1 | Minimum Viable Project Contract | [research-minimum-viable-project-contract.md](research-minimum-viable-project-contract.md) | High | 🔴 Not Started |
+| 2 | Per-Repo Profile Location and Schema | [research-per-repo-profile-location-and-schema.md](research-per-repo-profile-location-and-schema.md) | High | 🔴 Not Started |
+| 3 | Skill Corpus Ownership Model | [research-skill-corpus-ownership-model.md](research-skill-corpus-ownership-model.md) | Medium | 🔴 Not Started |
+| 4 | Template Skill Bundling Strategy | [research-template-skill-bundling-strategy.md](research-template-skill-bundling-strategy.md) | Medium | 🔴 Not Started |
+| 5 | Migration Path for Existing Projects | [research-migration-path-for-existing-projects.md](research-migration-path-for-existing-projects.md) | Low | 🔴 Not Started |
+| 6 | `global-command-distribution` Requirements Audit | [research-global-command-distribution-requirements-audit.md](research-global-command-distribution-requirements-audit.md) | Medium | 🔴 Not Started |
+| 7 | Meta Work-Unit Naming | [research-meta-work-unit-naming.md](research-meta-work-unit-naming.md) | Low | 🔴 Not Started |
+
+---
+
+## Research Overview
+
+This research spans three interconnected concerns:
+
+1. **What do templates become?** (Topics 1, 4, 5) — Define the minimal template, decide bundling strategy, plan migration
+2. **What enables skills to work anywhere?** (Topic 2) — Per-repo profile location and schema (ai-workflow substrate, consumed by meta decisions)
+3. **What's the organizational model?** (Topics 3, 6, 7) — Skill ownership, requirements reuse, naming conventions
+
+**Recommended conduct order:** Topics 1 and 2 first (they constrain the others), then Topic 6 (reuse existing research), then Topics 3–4 (depend on 1+2 findings), then Topics 5 and 7 (lowest priority, least dependent).
+
+---
+
+## Next Steps
+
+1. Use `research-conduct` to investigate Topics 1 and 2 (highest priority, unblock all other topics)
+2. Topic 6 is housekeeping — audit the existing `global-command-distribution` requirements early to avoid duplicating work
+3. After all topics complete, use `research-consolidate` to reconcile findings and finalize requirements

--- a/admin/services/meta/features/skill-template-separation/research/requirements.md
+++ b/admin/services/meta/features/skill-template-separation/research/requirements.md
@@ -1,0 +1,49 @@
+# Requirements — Skill-Template Separation
+
+**Status:** Draft
+**Created:** 2026-05-06
+**Last Updated:** 2026-05-06
+
+---
+
+## Overview
+
+Requirements extracted from research findings across 7 topics. This document starts as a skeleton and is populated during research-conduct, then consolidated and finalized during research-consolidate.
+
+---
+
+## Functional Requirements
+
+*(Extracted during research-conduct — no fabricated FR IDs until findings support them)*
+
+---
+
+## Non-Functional Requirements
+
+*(Extracted during research-conduct)*
+
+---
+
+## Constraints
+
+*(Extracted during research-conduct)*
+
+---
+
+## Assumptions
+
+*(Extracted during research-conduct)*
+
+---
+
+## Traceability
+
+| Requirement | Source Topic | Evidence |
+|-------------|-------------|----------|
+| *(populated during consolidate)* | | |
+
+---
+
+## Next Steps
+
+Requirements are extracted as research proceeds. After all topics are complete, use research-consolidate to deduplicate, prioritize, and move from Draft to Final status.

--- a/admin/services/meta/features/skill-template-separation/research/requirements.md
+++ b/admin/services/meta/features/skill-template-separation/research/requirements.md
@@ -14,19 +14,53 @@ Requirements extracted from research findings across 7 topics. This document sta
 
 ## Functional Requirements
 
-*(Extracted during research-conduct — no fabricated FR IDs until findings support them)*
+### FR-MVPC-1: AGENTS.md Required
+The minimal template MUST include AGENTS.md with project conventions sufficient for AI agents to operate without exploration.
+**Source:** Topic 1 — Finding 2 (AGENTS.md standard), Finding 7 (agent landing site)
+
+### FR-MVPC-2: proj-cli State File Required
+The minimal template MUST include `.dev-infra.yml` for proj-cli state tracking (template version, customizations).
+**Source:** Topic 1 — Finding 3 (proj-cli needs)
+
+### FR-MVPC-3: Git Hygiene for Agent Scratch
+The minimal template MUST include `.gitignore` with entries for agent scratch paths (`.scratch/`, `tmp/`, `admin/tmp/`).
+**Source:** Topic 1 — Finding 7 (scratch path convention)
+
+### FR-MVPC-4: README with Project Identity
+The minimal template SHOULD include a README.md with project identity and getting-started instructions.
+**Source:** Topic 1 — Finding 6 (modern scaffold convergence)
+
+### FR-MVPC-5: No Pre-Built Skill Structure
+The minimal template SHOULD NOT include directory structure that skills create on demand (explorations, research, decisions, planning).
+**Source:** Topic 1 — Finding 4 (skills create on demand), Finding 5 (80% analysis)
+
+### FR-MVPC-6: No Bundled Skills/Commands/Agents
+The minimal template MUST NOT bundle skills, commands, or agents (these are global installs with independent lifecycle).
+**Source:** Topic 1 — Finding 5 (migration already done)
 
 ---
 
 ## Non-Functional Requirements
 
-*(Extracted during research-conduct)*
+### NFR-MVPC-1: Fast Generation
+The minimal template SHOULD be generatable in < 5 seconds with no network calls.
+**Source:** Topic 1 — Finding 6 (modern scaffold UX)
+
+### NFR-MVPC-2: Immediate Operability
+The minimal template SHOULD produce a working project (passes CI, agents can operate) immediately after generation without additional setup steps.
+**Source:** Topic 1 — Finding 6 (day-one productivity)
 
 ---
 
 ## Constraints
 
-*(Extracted during research-conduct)*
+### C-MVPC-1: AGENTS.md Must Be Parameterized
+AGENTS.md content depends on project type (tech stack, framework, conventions). The template must parameterize this rather than shipping a generic placeholder.
+**Source:** Topic 1 — Analysis
+
+### C-MVPC-2: No Breaking Existing Projects
+Existing projects generated from comprehensive templates are not affected — they keep their structure. Migration is a separate concern (Topic 5).
+**Source:** Topic 1 — Analysis
 
 ---
 

--- a/admin/services/meta/features/skill-template-separation/research/research-global-command-distribution-requirements-audit.md
+++ b/admin/services/meta/features/skill-template-separation/research/research-global-command-distribution-requirements-audit.md
@@ -1,0 +1,69 @@
+# Research: `global-command-distribution` Requirements Audit
+
+**Status:** 🔴 Not Started
+**Priority:** Medium
+**Created:** 2026-05-06
+
+---
+
+## Research Question
+
+Which requirements from the December 2025 `global-command-distribution` feature still apply, which are outdated, and which should be absorbed into this research?
+
+---
+
+## Research Goals
+
+- [ ] Read and catalog all requirements from `admin/services/meta/features/global-command-distribution/requirements.md`
+- [ ] For each FR (FR-1 through FR-5): assess current status (done? obsolete? still needed?)
+- [ ] For each NFR (NFR-1, NFR-2): assess relevance to the separation model
+- [ ] For each constraint (C-1, C-2): assess whether they still hold
+- [ ] Identify requirements that should be absorbed directly into this research's `requirements.md`
+- [ ] Identify requirements that are superseded by reality (global installs already exist)
+- [ ] Determine disposition of the `global-command-distribution` feature itself (mark superseded? archive? absorb?)
+
+---
+
+## Methodology
+
+*(To be filled during research-conduct)*
+
+---
+
+## Sources
+
+- [ ] `admin/services/meta/features/global-command-distribution/requirements.md`
+- [ ] `admin/services/meta/features/global-command-distribution/README.md`
+- [ ] Four-arm architecture ADR-001 (command distribution ownership — already decided)
+- [ ] Current global install state (`~/.cursor/skills/`, `~/.cursor/commands/`, `~/.cursor/agents/`)
+- [ ] `admin/planning/standards/command-distribution/` — existing standard
+
+---
+
+## Findings
+
+*(To be filled during research-conduct)*
+
+---
+
+## Analysis
+
+*(To be filled during research-conduct)*
+
+---
+
+## Recommendations
+
+*(To be filled during research-conduct)*
+
+---
+
+## Requirements Discovered
+
+*(To be extracted during research-conduct and consolidated in requirements.md)*
+
+---
+
+## Next Steps
+
+This is housekeeping — can be done early and quickly. Read existing docs, mark status on each requirement, produce a disposition table. No web search needed.

--- a/admin/services/meta/features/skill-template-separation/research/research-meta-work-unit-naming.md
+++ b/admin/services/meta/features/skill-template-separation/research/research-meta-work-unit-naming.md
@@ -1,0 +1,67 @@
+# Research: Meta Work-Unit Naming
+
+**Status:** 🔴 Not Started
+**Priority:** Low
+**Created:** 2026-05-06
+
+---
+
+## Research Question
+
+Should meta-level work units be called "initiatives" (or something else), and should the directory structure change from `features/` to reflect this?
+
+---
+
+## Research Goals
+
+- [ ] Catalog existing naming: "feature" (product delivery), "exploration" (pre-formal thinking), "maintenance" (operational upkeep)
+- [ ] Assess "initiative" as a name for meta-level coordinated work that reshapes internal operations
+- [ ] Evaluate alternatives: "initiative", "program", "track", "workstream", "evolution"
+- [ ] Determine if directory structure should change (`features/` → `initiatives/`) or if naming is just conceptual
+- [ ] Assess migration cost: renaming existing `features/` directories vs. using new name going forward only
+- [ ] Define how the roadmap artifact (`admin/services/meta/roadmap.md`) references work units by name
+
+---
+
+## Methodology
+
+*(To be filled during research-conduct)*
+
+---
+
+## Sources
+
+- [ ] Current `admin/services/meta/features/` listing — what exists under "features" today
+- [ ] `admin/services/meta/explorations/skill-template-separation/exploration.md` Theme 4 — initial framing
+- [ ] PiHole-DNS project service-level `roadmap.md` — precedent for roadmap artifact shape
+- [ ] Web search: terminology for internal infrastructure work (TOGAF, SAFe portfolio/program/initiative, Spotify model)
+
+---
+
+## Findings
+
+*(To be filled during research-conduct)*
+
+---
+
+## Analysis
+
+*(To be filled during research-conduct)*
+
+---
+
+## Recommendations
+
+*(To be filled during research-conduct)*
+
+---
+
+## Requirements Discovered
+
+*(To be extracted during research-conduct and consolidated in requirements.md)*
+
+---
+
+## Next Steps
+
+Lowest priority — this is a naming decision, not a technical risk. Quick resolution after other topics provide context for what meta work units actually look like in practice.

--- a/admin/services/meta/features/skill-template-separation/research/research-migration-path-for-existing-projects.md
+++ b/admin/services/meta/features/skill-template-separation/research/research-migration-path-for-existing-projects.md
@@ -1,0 +1,67 @@
+# Research: Migration Path for Existing Projects
+
+**Status:** 🔴 Not Started
+**Priority:** Low
+**Created:** 2026-05-06
+
+---
+
+## Research Question
+
+What happens to projects already generated from the comprehensive template? Do they get a migration command, or do they just keep their existing structure indefinitely?
+
+---
+
+## Research Goals
+
+- [ ] Inventory projects generated from comprehensive templates (PiHole-DNS, support-shark, others)
+- [ ] Assess what "migration" means: removing scaffold? Slimming docs? Adding profile? All of the above?
+- [ ] Evaluate "do nothing" option: existing projects keep their structure, new projects start minimal
+- [ ] Evaluate migration command: `proj migrate --to-minimal` that strips scaffold and adds profile
+- [ ] Evaluate incremental approach: skills gradually stop depending on pre-built structure, existing projects naturally slim
+- [ ] Determine if proj-cli's `proj plan` / `proj apply` mechanism could handle template version migration
+
+---
+
+## Methodology
+
+*(To be filled during research-conduct)*
+
+---
+
+## Sources
+
+- [ ] `proj-cli` design docs — does it already handle template version upgrades?
+- [ ] Existing projects' actual directory listings (what do they use vs. what's unused scaffold?)
+- [ ] `proj-cli-focused-role` exploration — proj-cli's sync scope and lifecycle role
+- [ ] Web search: template migration patterns (Rails generators, Create React App eject, framework upgrade guides)
+
+---
+
+## Findings
+
+*(To be filled during research-conduct)*
+
+---
+
+## Analysis
+
+*(To be filled during research-conduct)*
+
+---
+
+## Recommendations
+
+*(To be filled during research-conduct)*
+
+---
+
+## Requirements Discovered
+
+*(To be extracted during research-conduct and consolidated in requirements.md)*
+
+---
+
+## Next Steps
+
+Lowest priority — address after Topics 1 and 4 determine what "minimal" means and how bundling works. The answer may be "do nothing; existing projects are fine."

--- a/admin/services/meta/features/skill-template-separation/research/research-minimum-viable-project-contract.md
+++ b/admin/services/meta/features/skill-template-separation/research/research-minimum-viable-project-contract.md
@@ -1,8 +1,9 @@
 # Research: Minimum Viable Project Contract
 
-**Status:** 🔴 Not Started
+**Status:** ✅ Complete
 **Priority:** High
 **Created:** 2026-05-06
+**Completed:** 2026-05-06
 
 ---
 
@@ -14,57 +15,219 @@ What's the minimum set of files/structure that `proj-cli`/`work-prod` and AI age
 
 ## Research Goals
 
-- [ ] Identify what `proj-cli` requires to detect and manage a project (state file, manifest, etc.)
-- [ ] Identify what AI agents (skills, commands, agents) require to operate in a repo (scratch path, AGENTS.md, profile pointer)
-- [ ] Identify what `work-prod` requires to register and track a project (registry entry, metadata)
-- [ ] Determine the boundary between "template provides" and "on-demand creation by skills/tools"
-- [ ] Produce a candidate list of "day-one files" that constitute the minimal template
-- [ ] Compare against what the current comprehensive template provides to understand what would be removed
+- [x] Identify what `proj-cli` requires to detect and manage a project (state file, manifest, etc.)
+- [x] Identify what AI agents (skills, commands, agents) require to operate in a repo (scratch path, AGENTS.md, profile pointer)
+- [x] Identify what `work-prod` requires to register and track a project (registry entry, metadata)
+- [x] Determine the boundary between "template provides" and "on-demand creation by skills/tools"
+- [x] Produce a candidate list of "day-one files" that constitute the minimal template
+- [x] Compare against what the current comprehensive template provides to understand what would be removed
 
 ---
 
 ## Methodology
 
-*(To be filled during research-conduct)*
+**Queries executed:**
+1. "minimal project scaffold template 2025 2026 what files are essential for project initialization cookiecutter cargo init yeoman"
+2. "AGENTS.md project configuration file AI coding assistants 2025 2026 agentskills.io"
+3. "minimal viable project template scaffold what files necessary 2026 developer experience day one productivity"
+
+**Internal sources consulted:**
+- `templates/standard-project/` full file listing (89 files)
+- `templates/learning-project/` full file listing (50 files)
+- `admin/services/meta/features/project-model-definition/requirements.md` — proj-cli/work-prod API contract
+- `admin/services/ai-workflow/explorations/skill-package-controller/exploration.md` — agent requirements
+- `templates/standard-project/start.txt` — current initialization form
+- Global skills directory listing — which skills create structure on demand
 
 ---
 
 ## Sources
 
-- [ ] Current `templates/standard-project/` file listing (what exists today)
-- [ ] Current `templates/learning-project/` file listing (what exists today)
-- [ ] `proj-cli` source — what files does it read/write?
-- [ ] `work-prod` API — what project metadata does it require?
-- [ ] Existing skills that create files on first run (evidence of "on-demand" pattern)
-- [ ] `skill-package-controller` exploration — AGENTS.md as project contract candidate
-- [ ] Web search: minimal project scaffolds in other ecosystems (cookiecutter, yeoman, cargo init)
+- [x] Current `templates/standard-project/` file listing (89 files total)
+- [x] Current `templates/learning-project/` file listing (50 files total)
+- [x] `proj-cli` requirements — FR-1: only `name` field required on project create
+- [x] `work-prod` API — CRUD on projects, only `name` required, rest optional metadata
+- [x] Existing skills that create files on first run: `explore-start`, `research-setup`, `write-plan-setup`, `decision`, `int-opp`, `handoff`, `pre-commit-review` — all create directory structure on demand
+- [x] `skill-package-controller` exploration — AGENTS.md as project contract, three-tier authority model
+- [x] Web search: minimal scaffolds in other ecosystems (see Methodology)
 
 ---
 
 ## Findings
 
-*(To be filled during research-conduct)*
+### Finding 1: Cargo/Rust — The Minimalist Standard
+
+**Source:** Web search: "minimal project scaffold template 2025 2026"
+**Relevance:** Cargo is the gold standard for minimal project initialization. `cargo init` creates exactly 3 artifacts: `Cargo.toml` (manifest), `src/main.rs` (entry point), `.gitignore`. Everything else is opt-in via `cargo add`, crate features, or workspace configuration.
+
+The pattern: **manifest + entry point + git hygiene**. No pre-built directory tree, no documentation scaffold, no CI config. Those arrive when needed.
+
+### Finding 2: AGENTS.md Is a Linux Foundation Standard (2026)
+
+**Source:** Web search: "AGENTS.md project configuration file AI coding assistants 2026"; mdskills.ai, morphllm.com, agents.md
+**Relevance:** AGENTS.md is now recognized across Claude Code, Cursor, GitHub Copilot, Codex, Gemini CLI, and Aider. Princeton research shows it reduced median agent runtime by 28.6% and token usage by 16.6% across 124 PRs. It's the "README for machines" — providing build commands, architecture, code style, and project rules in one file that all agents read.
+
+Key characteristics: plain markdown, no required fields, 32 KiB cap, supports nested files in monorepos. One file works across tools (unlike `.cursorrules` or `CLAUDE.md` which are tool-specific).
+
+**Implication for minimal template:** AGENTS.md is the single highest-leverage file for AI agent productivity. It replaces tool-specific configuration files and provides the project contract that the skill-package-controller's Tier 1 authority reads.
+
+### Finding 3: proj-cli/work-prod Need Almost Nothing
+
+**Source:** `admin/services/meta/features/project-model-definition/requirements.md` (FR-1, FR-1a)
+**Relevance:** The work-prod API requires only a `name` field to create a project. All other metadata (status, organization, classification) is optional. proj-cli's state file (`.dev-infra.yml`) tracks template version and customizations — it's the only proj-cli-specific file.
+
+**Implication:** The lifecycle tooling imposes almost zero file requirements on a repo. proj-cli needs its state file; work-prod needs nothing in-repo at all (it's an external registry).
+
+### Finding 4: Skills Create Their Own Structure On-Demand
+
+**Source:** Internal: `~/.cursor/skills/` — 15+ skills that create directories
+**Relevance:** The following skills create directory structure when first invoked:
+- `explore-start` → creates `explorations/[topic]/` with README, exploration.md, research-topics.md
+- `research-setup` → creates `research/` tree with hub, per-topic docs, summary, requirements
+- `write-plan-setup` → creates `planning/` tree with implementation plan, status, task group skeleton
+- `decision` → creates `decisions/` tree with ADR hub and templates
+- `int-opp` → creates `admin/planning/opportunities/` tree
+- `handoff` → creates `admin/tmp/handoffs/` or `tmp/handoffs/`
+- `pre-commit-review` → creates review bundle directory
+
+**Implication:** The comprehensive template pre-builds structure that skills would create on demand anyway. The `docs/maintainers/planning/explorations/`, `docs/maintainers/research/`, `docs/maintainers/decisions/` directories in the current template are all created by skills when they're actually needed. Pre-building them is wasted scaffolding — it's noise on day one and becomes stale if the skill's expectations change.
+
+### Finding 5: Current Templates Are 80% Pre-Built Structure That Skills Would Create
+
+**Source:** Internal: `templates/standard-project/` file listing analysis
+**Relevance:** Of the 89 files in `standard-project`:
+- **42 files** (47%) are skills/commands (`.claude/skills/`, `.cursor/commands/`) — already migrated to global installs
+- **24 files** (27%) are docs infrastructure (`docs/maintainers/` planning pipeline, examples, workflow guides) — created on demand by skills
+- **7 files** (8%) are structural empties (`README.md` files in empty directories, `.gitkeep` files)
+- **5 files** (6%) are CI/tooling config (`.github/workflows/ci.yml`, `.sourcery.yaml`, `.dockerignore`, `.gitignore`)
+- **3 files** (3%) are application scaffold (`backend/`, `frontend/` READMEs, root README)
+- **1 file** (1%) is the start form (`start.txt`)
+- **5 files** (6%) are root-level docs (`README.md`, `docs/README.md`, `scripts/README.md`, `tests/README.md`)
+
+**Bottom line:** Only ~10-15 files serve a purpose that can't be fulfilled on demand. The rest is either migrated to global installs, created by skills when needed, or structural noise.
+
+### Finding 6: Modern Scaffolds Converge on "Config + Entry Point + Git Hygiene"
+
+**Source:** Web search: "minimal viable project template scaffold 2026"
+**Relevance:** Across ecosystems (Vite, uv, cargo, cookiecutter), modern scaffolds converge on:
+1. **Package manifest** (Cargo.toml, pyproject.toml, package.json) — declares identity, deps, scripts
+2. **Source entry point** (src/main.rs, src/main.py, src/index.ts) — proves the stack works
+3. **Git configuration** (.gitignore) — prevents tracking of build artifacts
+4. **Optional:** CI pipeline, README, LICENSE
+
+The trend is away from comprehensive scaffolds and toward minimal starts with opt-in layers added via `add` commands (cargo add, npm install, etc.).
+
+### Finding 7: The "Agent Landing Site" Concept
+
+**Source:** Internal: `skill-package-controller` exploration Theme 3, Theme 4
+**Relevance:** The controller exploration identified that agents need a "landing site" — enough information to orient themselves in a repo without exploring. This is:
+1. **AGENTS.md** — project conventions, build commands, architecture (Tier 1 authority)
+2. **Scratch path convention** — where agents put transient artifacts (reviews, handoffs, planning)
+3. **Git hygiene for agent artifacts** — .gitignore entries for scratch paths
+
+Without these, agents either explore (wasteful) or assume (fragile). The minimal template's job is to provide this landing site, not to pre-build the structure that agents will create on demand.
 
 ---
 
 ## Analysis
 
-*(To be filled during research-conduct)*
+### The Three Consumers and Their Needs
+
+| Consumer | What it needs in-repo | What it needs externally |
+|----------|----------------------|-------------------------|
+| **proj-cli** | `.dev-infra.yml` (state file) | work-prod registry entry (API) |
+| **work-prod** | Nothing | `name` field via API |
+| **AI agents** | AGENTS.md (conventions), .gitignore (scratch hygiene) | Per-repo profile (paths, ticket config) |
+
+### The Boundary: Template Provides vs. On-Demand
+
+**Template provides (day-one files):**
+- Files that can't be meaningfully created by a tool at runtime because they require human knowledge (project name, conventions, tech stack)
+- Files that must exist before any tool runs (git config, agent conventions)
+
+**On-demand (skills create when needed):**
+- Directory structure for planning, research, decisions, explorations
+- CI/CD pipelines (depends on tech stack chosen later)
+- Documentation infrastructure (grows with the project)
+- Application scaffold (varies wildly by project type)
+
+### What the Current Template Gets Wrong
+
+The current template conflates three things:
+1. **Contract files** that tools need → should stay in template
+2. **Convenience scaffold** that saves one `mkdir` → should be on-demand
+3. **Workflow tooling** (skills/commands) → already migrated to global installs
+
+### Candidate Minimal Template
+
+Based on findings, the minimal template should contain **7-9 files**:
+
+| File | Purpose | Consumer |
+|------|---------|----------|
+| `AGENTS.md` | Project conventions for AI agents (build commands, architecture, rules) | All AI agents (Tier 1 authority) |
+| `.dev-infra.yml` | Template version and customization state | proj-cli |
+| `.gitignore` | Ignore build artifacts, agent scratch paths, editor files | Git, agents |
+| `README.md` | Project identity (name, description, tech stack, getting started) | Humans, GitHub |
+| `start.txt` | Project initialization form (filled during setup) | proj-cli setup flow |
+| `.github/workflows/ci.yml` | Minimal CI (lint + test, parameterized for tech stack) | GitHub Actions |
+| `src/` or entry point | Proves the stack works (varies by project type) | Developer |
+| `.sourcery.yaml` | Code review configuration | Sourcery |
+
+**Optional (include if project type warrants):**
+- `Dockerfile` + `.dockerignore` (if containerized)
+- `LICENSE` (if open source)
+
+### What Gets Removed (vs. current 89-file template)
+
+| Category | Files Removed | Reason |
+|----------|--------------|--------|
+| Skills/commands | 42 files | Migrated to global installs |
+| Docs infrastructure | 24 files | Created on demand by skills |
+| Structural empties | 7 files | No value until populated |
+| Backend/frontend scaffold | 2 files | Project-type dependent, not universal |
+| Workflow guides | 4 files | Available globally, not template-specific |
+
+**Reduction: 89 files → ~8 files (91% reduction)**
 
 ---
 
 ## Recommendations
 
-*(To be filled during research-conduct)*
+- [x] AGENTS.md should be the centerpiece of the minimal template — it's the highest-leverage file for both AI productivity and cross-tool compatibility
+- [ ] The template should stop bundling skills/commands entirely (they're global installs with independent release cadence)
+- [ ] Directory structure should be created on demand by skills, not pre-built by templates
+- [ ] `start.txt` should evolve from a form into a machine-readable manifest that proj-cli consumes during setup
+- [ ] The minimal template should be project-type-parameterized: the core contract files are universal, but the entry point and CI config vary by tech stack
+- [ ] Consider splitting into "contract layer" (AGENTS.md, .dev-infra.yml, .gitignore) and "starter layer" (README, CI, entry point) — the contract layer is truly minimal, the starter layer is opinionated but thin
 
 ---
 
 ## Requirements Discovered
 
-*(To be extracted during research-conduct and consolidated in requirements.md)*
+**FR-MVPC-1:** The minimal template MUST include AGENTS.md with project conventions sufficient for AI agents to operate without exploration.
+
+**FR-MVPC-2:** The minimal template MUST include `.dev-infra.yml` for proj-cli state tracking (template version, customizations).
+
+**FR-MVPC-3:** The minimal template MUST include `.gitignore` with entries for agent scratch paths (`.scratch/`, `tmp/`, `admin/tmp/`).
+
+**FR-MVPC-4:** The minimal template SHOULD include a README.md with project identity and getting-started instructions.
+
+**FR-MVPC-5:** The minimal template SHOULD NOT include directory structure that skills create on demand (explorations, research, decisions, planning).
+
+**FR-MVPC-6:** The minimal template MUST NOT bundle skills, commands, or agents (these are global installs with independent lifecycle).
+
+**NFR-MVPC-1:** The minimal template SHOULD be generatable in < 5 seconds with no network calls.
+
+**NFR-MVPC-2:** The minimal template SHOULD produce a working project (passes CI, agents can operate) immediately after generation without additional setup steps.
+
+**C-MVPC-1:** AGENTS.md content depends on project type (tech stack, framework, conventions). The template must parameterize this rather than shipping a generic placeholder.
+
+**C-MVPC-2:** Existing projects generated from comprehensive templates are not affected — they keep their structure. Migration is a separate concern (Topic 5).
 
 ---
 
 ## Next Steps
 
-Begin research-conduct for this topic. Pair with Topic 2 (per-repo profile) as findings are mutually constraining.
+- Findings feed directly into Topic 2 (per-repo profile) — the profile stores paths that the template no longer pre-builds
+- Findings inform Topic 4 (bundling strategy) — recommendation is "don't bundle skills at all"
+- The candidate minimal template (7-9 files) should be validated via spike: generate it for a real project and test whether skills/agents can operate without the pre-built infrastructure

--- a/admin/services/meta/features/skill-template-separation/research/research-minimum-viable-project-contract.md
+++ b/admin/services/meta/features/skill-template-separation/research/research-minimum-viable-project-contract.md
@@ -1,0 +1,70 @@
+# Research: Minimum Viable Project Contract
+
+**Status:** 🔴 Not Started
+**Priority:** High
+**Created:** 2026-05-06
+
+---
+
+## Research Question
+
+What's the minimum set of files/structure that `proj-cli`/`work-prod` and AI agents need to manage a project's lifecycle — i.e., what must be in the minimal template?
+
+---
+
+## Research Goals
+
+- [ ] Identify what `proj-cli` requires to detect and manage a project (state file, manifest, etc.)
+- [ ] Identify what AI agents (skills, commands, agents) require to operate in a repo (scratch path, AGENTS.md, profile pointer)
+- [ ] Identify what `work-prod` requires to register and track a project (registry entry, metadata)
+- [ ] Determine the boundary between "template provides" and "on-demand creation by skills/tools"
+- [ ] Produce a candidate list of "day-one files" that constitute the minimal template
+- [ ] Compare against what the current comprehensive template provides to understand what would be removed
+
+---
+
+## Methodology
+
+*(To be filled during research-conduct)*
+
+---
+
+## Sources
+
+- [ ] Current `templates/standard-project/` file listing (what exists today)
+- [ ] Current `templates/learning-project/` file listing (what exists today)
+- [ ] `proj-cli` source — what files does it read/write?
+- [ ] `work-prod` API — what project metadata does it require?
+- [ ] Existing skills that create files on first run (evidence of "on-demand" pattern)
+- [ ] `skill-package-controller` exploration — AGENTS.md as project contract candidate
+- [ ] Web search: minimal project scaffolds in other ecosystems (cookiecutter, yeoman, cargo init)
+
+---
+
+## Findings
+
+*(To be filled during research-conduct)*
+
+---
+
+## Analysis
+
+*(To be filled during research-conduct)*
+
+---
+
+## Recommendations
+
+*(To be filled during research-conduct)*
+
+---
+
+## Requirements Discovered
+
+*(To be extracted during research-conduct and consolidated in requirements.md)*
+
+---
+
+## Next Steps
+
+Begin research-conduct for this topic. Pair with Topic 2 (per-repo profile) as findings are mutually constraining.

--- a/admin/services/meta/features/skill-template-separation/research/research-per-repo-profile-location-and-schema.md
+++ b/admin/services/meta/features/skill-template-separation/research/research-per-repo-profile-location-and-schema.md
@@ -1,0 +1,70 @@
+# Research: Per-Repo Profile Location and Schema
+
+**Status:** 🔴 Not Started
+**Priority:** High
+**Created:** 2026-05-06
+
+---
+
+## Research Question
+
+Where should the unified per-repo skill profile live, what's its schema, and how do skills look it up?
+
+---
+
+## Research Goals
+
+- [ ] Evaluate candidate locations: `~/.cursor/repos/<slug>.yaml`, `~/.cursor/profiles/<slug>.yaml`, `~/.cursor/skills/_shared/repos/<slug>.yaml`, in-repo `.cursor/profile.yaml`
+- [ ] Define slug derivation strategy (repo basename, org/repo, remote URL hash, user-chosen)
+- [ ] Determine v1 schema fields: paths (artifact root, plan root, scratch), ticket conventions, skill version targeting
+- [ ] Assess migration cost of each location choice (if wrong, how hard to move later?)
+- [ ] Determine lookup convention: env var → explicit flag → config file → detection fallback
+- [ ] Evaluate relationship to `ticket-intake/repos/<slug>.yaml` (absorb, extend, or coexist?)
+- [ ] Determine whether in-repo files (AGENTS.md) can override/supplement the external profile
+
+---
+
+## Methodology
+
+*(To be filled during research-conduct)*
+
+---
+
+## Sources
+
+- [ ] `~/.cursor/skills/ticket-intake/repos/` — existing per-repo YAML precedent
+- [ ] `per-repo-skill-profile-unified.md` int-opp — proposed schema sketch
+- [ ] `skills-path-roots-configurable.md` int-opp — skill-level override patterns
+- [ ] `skill-package-controller` exploration — registry/controller relationship to profile
+- [ ] XDG Base Directory specification (for location conventions)
+- [ ] Web search: per-project configuration patterns in other tool ecosystems (direnv, mise, asdf, editorconfig)
+
+---
+
+## Findings
+
+*(To be filled during research-conduct)*
+
+---
+
+## Analysis
+
+*(To be filled during research-conduct)*
+
+---
+
+## Recommendations
+
+*(To be filled during research-conduct)*
+
+---
+
+## Requirements Discovered
+
+*(To be extracted during research-conduct and consolidated in requirements.md)*
+
+---
+
+## Next Steps
+
+Begin research-conduct for this topic. Findings directly constrain Topics 3 and 4 (ownership and bundling depend on how the profile works).

--- a/admin/services/meta/features/skill-template-separation/research/research-skill-corpus-ownership-model.md
+++ b/admin/services/meta/features/skill-template-separation/research/research-skill-corpus-ownership-model.md
@@ -1,0 +1,68 @@
+# Research: Skill Corpus Ownership Model
+
+**Status:** 🔴 Not Started
+**Priority:** Medium
+**Created:** 2026-05-06
+
+---
+
+## Research Question
+
+Does dev-infra continue to own the skill corpus (global installs as primary, dev-infra as the repo), or do skills become a separate project?
+
+---
+
+## Research Goals
+
+- [ ] Assess current state: which skills live only globally vs. which have dev-infra copies
+- [ ] Evaluate single-repo model: skills stay in dev-infra with a different release cadence (internal separation)
+- [ ] Evaluate split-repo model: skills get their own repo with independent versioning
+- [ ] Evaluate hybrid: dev-infra owns "core" skills, other skills are personal/per-project
+- [ ] Determine audience impact: if skills stay personal (never consumed by others), does repo separation matter?
+- [ ] Assess coordination cost of each model (release process, cross-repo PRs, testing)
+
+---
+
+## Methodology
+
+*(To be filled during research-conduct)*
+
+---
+
+## Sources
+
+- [ ] Current `git status` — mass deletions of `.claude/skills/` indicate de facto global-first
+- [ ] `~/.cursor/skills/` listing — what's installed globally now
+- [ ] `templates/standard-project/.claude/skills/` — what was in the template
+- [ ] Existing research from `global-command-distribution` feature (FR-3: version tracking)
+- [ ] Web search: dotfile management patterns (chezmoi, yadm, stow) for personal tool distribution
+
+---
+
+## Findings
+
+*(To be filled during research-conduct)*
+
+---
+
+## Analysis
+
+*(To be filled during research-conduct)*
+
+---
+
+## Recommendations
+
+*(To be filled during research-conduct)*
+
+---
+
+## Requirements Discovered
+
+*(To be extracted during research-conduct and consolidated in requirements.md)*
+
+---
+
+## Next Steps
+
+Depends on Topics 1 and 2 findings (if templates are minimal, the ownership question simplifies). Can begin in parallel with prior art survey.

--- a/admin/services/meta/features/skill-template-separation/research/research-summary.md
+++ b/admin/services/meta/features/skill-template-separation/research/research-summary.md
@@ -1,0 +1,73 @@
+# Research Summary — Skill-Template Separation
+
+**Status:** 🔴 Not Started
+**Created:** 2026-05-06
+**Last Updated:** 2026-05-06
+
+---
+
+## Overview
+
+7 research topics investigating how to separate skills/commands/agents from templates, what templates become after separation, and what substrate enables the transition.
+
+| Priority | Topics | Status |
+|----------|--------|--------|
+| High | 2 (Topics 1, 2) | 🔴 Not Started |
+| Medium | 3 (Topics 3, 4, 6) | 🔴 Not Started |
+| Low | 2 (Topics 5, 7) | 🔴 Not Started |
+
+---
+
+## Key Findings
+
+*(Populated after research-conduct completes each topic)*
+
+### Topic 1: Minimum Viable Project Contract
+
+*(Not yet researched)*
+
+### Topic 2: Per-Repo Profile Location and Schema
+
+*(Not yet researched)*
+
+### Topic 3: Skill Corpus Ownership Model
+
+*(Not yet researched)*
+
+### Topic 4: Template Skill Bundling Strategy
+
+*(Not yet researched)*
+
+### Topic 5: Migration Path for Existing Projects
+
+*(Not yet researched)*
+
+### Topic 6: `global-command-distribution` Requirements Audit
+
+*(Not yet researched)*
+
+### Topic 7: Meta Work-Unit Naming
+
+*(Not yet researched)*
+
+---
+
+## Cross-Topic Patterns
+
+*(Populated during research-consolidate — patterns that emerge across multiple topics)*
+
+---
+
+## Requirements Summary
+
+See [requirements.md](requirements.md) for the full requirements document.
+
+*(Requirements extracted from each topic's findings during research-conduct, consolidated and deduped during research-consolidate)*
+
+---
+
+## Next Steps
+
+1. Begin research-conduct on Topics 1 and 2 (highest priority, unblock others)
+2. Topic 6 can proceed in parallel (pure audit of existing docs)
+3. After all topics complete → research-consolidate → decision phase

--- a/admin/services/meta/features/skill-template-separation/research/research-summary.md
+++ b/admin/services/meta/features/skill-template-separation/research/research-summary.md
@@ -24,7 +24,7 @@
 
 ### Topic 1: Minimum Viable Project Contract
 
-*(Not yet researched)*
+The current 89-file standard template is 91% removable: 47% is skills/commands (migrated to global installs), 27% is docs infrastructure (created on demand by skills), 8% is structural empties. The minimal template converges on **7-9 files**: AGENTS.md (AI agent contract), `.dev-infra.yml` (proj-cli state), `.gitignore` (scratch hygiene), README.md (human identity), and optionally CI config + entry point. Key insight: skills create their own structure on demand — pre-building it is wasted scaffolding that becomes stale. AGENTS.md is the highest-leverage file (Linux Foundation standard, 28.6% agent runtime reduction per Princeton research).
 
 ### Topic 2: Per-Repo Profile Location and Schema
 

--- a/admin/services/meta/features/skill-template-separation/research/research-template-skill-bundling-strategy.md
+++ b/admin/services/meta/features/skill-template-separation/research/research-template-skill-bundling-strategy.md
@@ -1,0 +1,69 @@
+# Research: Template Skill Bundling Strategy
+
+**Status:** 🔴 Not Started
+**Priority:** Medium
+**Created:** 2026-05-06
+
+---
+
+## Research Question
+
+After separation, do templates still bundle a subset of skills (as release snapshots), or do they rely entirely on global installs and just document which skills they expect?
+
+---
+
+## Research Goals
+
+- [ ] Define "bundling" precisely: full skill copy in template vs. manifest/lockfile referencing skills
+- [ ] Evaluate Model A (snapshot at release): templates include skills at release time, generated projects start with them
+- [ ] Evaluate Model B (no bundling): templates carry no skills, document expected global installs instead
+- [ ] Evaluate Model C (manifest only): templates include a skill manifest that a setup command resolves
+- [ ] Assess self-containment tradeoff: can a generated project work without global installs?
+- [ ] Determine what the `workflow-decoupling` exploration's "package manager question" means for each model
+- [ ] Assess version drift: if templates snapshot skills, how quickly do they go stale?
+
+---
+
+## Methodology
+
+*(To be filled during research-conduct)*
+
+---
+
+## Sources
+
+- [ ] Current `template-sync-manifest.txt` — what's synced today and why
+- [ ] `workflow-decoupling` exploration (template-generation) — Themes 4 and 5 (package manager, versioning)
+- [ ] Four-arm architecture ADR-001 — command distribution ownership decision
+- [ ] Issue #73 — template drift documentation
+- [ ] Web search: package bundling vs. dependency declaration patterns (npm bundledDependencies, pip freeze vs requirements, cargo vendor)
+
+---
+
+## Findings
+
+*(To be filled during research-conduct)*
+
+---
+
+## Analysis
+
+*(To be filled during research-conduct)*
+
+---
+
+## Recommendations
+
+*(To be filled during research-conduct)*
+
+---
+
+## Requirements Discovered
+
+*(To be extracted during research-conduct and consolidated in requirements.md)*
+
+---
+
+## Next Steps
+
+Depends on Topics 1 and 3 (what the minimal template contains and who owns skills). Begin after those topics produce findings.

--- a/admin/services/template-generation/explorations/workflow-decoupling/exploration.md
+++ b/admin/services/template-generation/explorations/workflow-decoupling/exploration.md
@@ -109,6 +109,12 @@ from the structural scaffold so that both can evolve independently.
 
 ---
 
+## 🔗 Sibling Explorations
+
+- **[Skill-Template Separation](../../../meta/explorations/skill-template-separation/)** (meta service) — Asks "what *is* the separation and what does a template become after?" while this exploration asks "how do we distribute what's been separated?" The two are complementary halves of the same initiative. Research and decisions should proceed in coordination.
+
+---
+
 ## 🚀 Next Steps
 
 Review this exploration, then:


### PR DESCRIPTION
## Summary

- Add "Why Dev-Infra Exists" narrative section to README covering the apprenticeship origin, learning-driven sprawl, and the dual need for project lifecycle management and thinking workflows
- Add "How the Project Found Its Focus" subsection telling the identity pivot story (lab/factory/reference → template factory) in reader-facing prose
- Add "What Dev-Infra Has Produced" subsection naming 5 downstream projects (proj-cli, piHole-DNS, OurFileServer, work-prod, support-shark) as proof that the patterns work
- Create implementation plan scaffolding for the full README narrative feature (9 tasks across 3 groups, 3/9 complete)

## Why

Research on 2026 narrative-driven README conventions identified that dev-infra's README has no origin section — it reads as a product spec sheet that hides a 7-month, 1,100+ commit project with 14 ADRs behind emoji headers and feature bullets. The README actively undersells the project by omitting context about why it exists, how it evolved, and what it has produced. This PR adds the narrative content (Group 1 of the plan); Groups 2 and 3 (README restructure, start.txt reconciliation) are planned but not yet implemented.

## After Merge

No downstream effects — docs-only change. The README gains ~30 lines of narrative content inserted between the status badges and Quick Start section. Existing README structure is preserved; the restructure (removing duplicates, fixing stale refs, reordering sections) is a separate task group.

## Follow-ups

- Task 4–7: README restructure (reorder sections, consolidate duplicates, fix stale version refs and placeholder links, make technical details secondary)
- Task 8–9: start.txt reconciliation (fill in actual project context, ensure consistency with README origin section)