### PR TITLE
docs: restructure README — consolidate, update refs, collapsible details

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,18 +42,14 @@ Each of these projects started from a dev-infra template and inherited the same 
 
 ---
 
-## 🚀 Quick Start
+## Quick Start
 
-### 1. Get Dev-Infra
+### 1. Get dev-infra
 
 **Option A: Download Distribution (Recommended)**
 ```bash
-# Download clean package (Linux/Mac)
 curl -L https://github.com/grimm00/dev-infra/releases/download/v0.6.0/dev-infra-0.6.0.tar.gz | tar -xz
 cd dev-infra-0.6.0
-
-# Or download for Windows
-curl -L https://github.com/grimm00/dev-infra/releases/download/v0.6.0/dev-infra-0.6.0.zip -o dev-infra.zip
 ```
 
 **Option B: Clone Repository**
@@ -68,362 +64,124 @@ See [Integration Guide](docs/INTEGRATION.md) for version-pinned download approac
 ### 2. Create Your Project
 
 ```bash
-# Generate new project
 ./scripts/new-project.sh
-
-# Validate templates
-./scripts/validate-templates.sh
 ```
 
-**Choose your project type:**
+Choose your project type:
 
-- **Standard Project** - Applications, tools, services
-- **Learning Project** - Tutorials, courses, exercises
+- **Standard Project** — Applications, tools, services, APIs
+- **Learning Project** — Tutorials, courses, exercises
 
----
+### 3. Customize
 
-## 🚀 What is Dev-Infra?
-
-Dev-infra provides standardized project templates that incorporate proven patterns from real-world projects. It eliminates the need to recreate project structure and workflows from scratch, ensuring consistency and quality across all your projects.
-
-### Key Benefits
-
-- **🏗️ Consistent Structure** - Every project starts with proven organization
-- **⚡ Quick Setup** - Interactive generator creates projects in minutes
-- **📚 Best Practices** - Built-in patterns from successful projects
-- **🤖 AI-Friendly** - Structure optimized for AI assistance
-- **🔧 Flexible** - Adapt templates to your specific needs
-- **📖 Well-Documented** - Comprehensive guides and examples
+- Update `start.txt` with project details and goals
+- Customize `README.md` with your technology stack
+- Configure CI/CD workflows
+- Remove unused directories, add project-specific ones
 
 ---
 
-## 📁 Project Templates
+## Project Templates
 
-### Standard Project Template
+### Standard Project
 
-**For:** Applications, tools, services, APIs
-
-**Features:**
-
-- Hub-and-spoke documentation pattern
-- Feature-based planning and tracking
-- Backend/frontend separation
-- Centralized testing structure
-- CI/CD workflows
-- Maintainers directory for project management
-
-**Structure:**
+For applications, tools, services, and APIs. Includes hub-and-spoke documentation, feature-based planning, backend/frontend separation, centralized testing, and CI/CD workflows.
 
 ```
 project/
 ├── docs/
 │   └── maintainers/  # Project management hub
-├── backend/          # Backend application (includes instance/)
+├── backend/          # Backend application
 ├── frontend/         # Frontend application
 ├── tests/            # Centralized testing
 ├── scripts/          # Automation
-├── docs/             # User documentation
 └── .github/          # CI/CD workflows
 ```
 
-### Learning Project Template
+### Learning Project
 
-**For:** Tutorials, courses, exercises, reference materials
-
-**Features:**
-
-- Stage-based learning progression
-- Fundamentals before implementation
-- Hands-on exercises
-- Reference materials
-- Practice applications
-- Educational content structure
-
-**Structure:**
+For tutorials, courses, and exercises. Uses stage-based progression from fundamentals through implementation, with reference materials and practice applications.
 
 ```
 project/
 ├── stage0-fundamentals/  # Core concepts
-├── stage1-[topic]/      # First learning stage
-├── stage2-[topic]/      # Second learning stage
-├── stage3-[topic]/      # Third learning stage
-├── reference/           # Quick reference
-├── practice-apps/       # Hands-on practice
+├── stage1-[topic]/       # Learning stages
+├── stage2-[topic]/
+├── reference/            # Quick reference
+├── practice-apps/        # Hands-on practice
 └── docs/
-    └── maintainers/     # Learning management
+    └── maintainers/      # Learning management
 ```
 
 ---
 
-## 🎨 Design Philosophy
+## Design Philosophy
 
 ### Hub-and-Spoke Documentation
 
-Every template uses a hub-and-spoke documentation pattern:
+Every template uses a hub-and-spoke documentation pattern: hub files (README.md) serve as entry points with quick links, spoke directories contain focused single-topic content, and progressive disclosure guides readers from overview to detail.
 
-- **Hub Files** (README.md) serve as entry points with quick links
-- **Spoke Directories** contain focused, single-topic content
-- **Progressive Disclosure** from overview to detailed implementation
-- **Consistent Navigation** across all project types
+### Patterns from Real Projects
 
-### Best Practices Integration
+Templates incorporate patterns learned from real projects — Pokehub (full-stack structure), dev-toolkit (CLI organization), and Containers (learning progression). These aren't theoretical best practices; they're patterns that survived contact with real codebases.
 
-Templates incorporate patterns learned from real projects:
+### Flexibility
 
-- **Pokehub** - Full-stack application structure
-- **Dev-toolkit** - Command-line tool organization
-- **Containers** - Learning project progression
-
-### Flexibility and Adaptation
-
-- Not all directories required for every project
-- Easy to remove unused sections
-- Simple to add project-specific directories
-- Maintains core structural principles
+Not all directories are required for every project. Templates are designed to be trimmed (remove what you don't need) or extended (add project-specific directories) while maintaining core structural principles.
 
 ---
 
-## 🔗 Dev-Toolkit Integration
+## Dev-Toolkit Integration
 
-Dev-infra is designed for seamless integration with dev-toolkit projects:
+Dev-infra integrates with dev-toolkit for version-pinned template management:
 
-### Version-Pinned Downloads (Recommended)
 ```bash
-# In dev-toolkit configuration
 DEVINFRA_VERSION="0.6.0"
 curl -L "https://github.com/grimm00/dev-infra/archive/v${DEVINFRA_VERSION}.tar.gz" | tar -xz
 ```
 
-### Integration Commands
-```bash
-# Dev-toolkit new commands
-dev-toolkit install-templates [version]
-dev-toolkit new-project --template regular
-dev-toolkit new-project --template learning
-dev-toolkit update-templates
-```
-
-### Benefits
-- **No Git Dependencies** - Download and extract approach
-- **Version Control** - Pin to specific stable versions
-- **Fast Integration** - Quick download and setup
-- **Easy Updates** - Change version number to update
-
-See [Integration Guide](docs/INTEGRATION.md) for complete implementation examples.
+See [Integration Guide](docs/INTEGRATION.md) for complete examples.
 
 ---
 
-## 🛠️ Technology Stack
+## Documentation
 
-### Core Technologies
-
-- **Documentation** - Markdown with hub-and-spoke pattern
-- **Version Control** - Git with Git Flow branching
-- **CI/CD** - GitHub Actions with branch-based workflows
-- **AI Integration** - Cursor IDE with custom rules
-- **Automation** - Bash scripts for project generation
-
-### External Integrations
-
-- **Sourcery AI** - Code review and quality analysis
-- **Bugbot** - Bug detection and prevention
-- **GitHub CLI** - Repository management
-- **Dev-toolkit** - Workflow automation
+- **[Template Usage Guide](docs/TEMPLATE-USAGE.md)** — How to use templates
+- **[Project Types Guide](docs/PROJECT-TYPES.md)** — Standard vs Learning comparison
+- **[Best Practices Guide](docs/BEST-PRACTICES.md)** — Template best practices
+- **[Customization Guide](docs/CUSTOMIZATION.md)** — Advanced customization
+- **[Standard Project Template](templates/standard-project/)** — Application template source
+- **[Learning Project Template](templates/learning-project/)** — Educational template source
 
 ---
 
-## 📊 Template Statistics
+## Contributing
 
-- **Templates Available** - 2 (Regular, Learning)
-- **Example Projects Analyzed** - 3 (Pokehub, dev-toolkit, containers)
-- **Documentation Patterns** - Hub-and-spoke, progressive disclosure
-- **Automation Scripts** - 1 (Interactive project generator)
-- **CI/CD Workflows** - 1 (Branch-based automation)
-
----
-
-## 🚀 Getting Started
-
-### 1. Generate New Project
-
-```bash
-# Interactive project creation
-./scripts/new-project.sh
-
-# Follow prompts:
-# - Enter project name and description
-# - Choose project type (Regular/Learning)
-# - Customize settings
-# - Initialize git repository
-```
-
-### 2. Customize Template
-
-**Required:**
-
-- Update `start.txt` with project details
-- Customize `README.md` with technology stack
-- Configure CI/CD workflows
-
-**Optional:**
-
-- Remove unused directories
-- Add project-specific directories
-- Customize admin structure
-
-### 3. Start Development
-
-**Standard Projects:**
-
-- Create first feature in `docs/maintainers/planning/features/`
-- Set up development environment
-- Begin feature development
-
-**Learning Projects:**
-
-- Start with `stage0-fundamentals/`
-- Follow learning progression
-- Complete exercises as you go
+1. Fork the repository
+2. Create a feature branch (`feat/improve-templates`)
+3. Make changes following hub-and-spoke patterns
+4. Test templates using `./scripts/new-project.sh` and `./scripts/validate-templates.sh`
+5. Submit a pull request
 
 ---
 
-## 📚 Documentation
-
-### User Guides
-
-- **[Template Usage Guide](docs/TEMPLATE-USAGE.md)** - How to use templates
-- **[Project Types Guide](docs/PROJECT-TYPES.md)** - Regular vs Learning comparison
-- **[Best Practices Guide](docs/BEST-PRACTICES.md)** - Template best practices
-- **[Customization Guide](docs/CUSTOMIZATION.md)** - Advanced customization
-
-### Template Examples
-
-- **[Standard Project Template](templates/standard-project/)** - Application template
-- **[Learning Project Template](templates/learning-project/)** - Educational template
-
-### Real Project Examples
-
-- **[Hub-and-Spoke Patterns](admin/notes/examples/hub-and-spoke-documentation-best-practices.md)** - Documentation patterns
-- **[Project Structures](admin/notes/examples/)** - Structure examples from real projects
-- **[CI/CD Workflows](admin/notes/examples/ci.yml.example)** - Workflow patterns
-- **[AI Rules](admin/notes/examples/main.mdc.example)** - Cursor IDE rules
-
----
-
-## 🔧 Development
-
-### Project Structure
+## Project Structure
 
 ```
 dev-infra/
 ├── templates/              # Project templates
 │   ├── standard-project/   # Application template
-│   └── learning-project/  # Educational template
-├── scripts/               # Automation scripts
-│   └── new-project.sh     # Project generator
-├── docs/                  # User documentation
-├── admin/                 # Dev-infra management
-│   ├── planning/          # Template roadmap
-│   ├── research/          # Design decisions
-│   └── notes/examples/    # Real project examples
-└── .cursor/               # AI assistant rules
-    └── rules/main.mdc     # Cursor IDE configuration
+│   └── learning-project/   # Educational template
+├── scripts/                # Automation scripts
+├── docs/                   # User documentation
+├── admin/                  # Dev-infra project management
+│   └── services/           # Service-first organization
+└── .cursor/                # IDE configuration
 ```
 
-### Contributing
-
-1. **Fork the repository**
-2. **Create feature branch** (`feat/improve-templates`)
-3. **Make changes** following hub-and-spoke pattern
-4. **Test templates** using generator script
-5. **Submit pull request** with clear description
-
-### Template Evolution
-
-Templates evolve based on:
-
-- Real project experience
-- User feedback
-- Best practice discoveries
-- Tool integration improvements
-
 ---
 
-## 🎯 Use Cases
-
-### Individual Developers
-
-- Consistent project structure
-- Quick project setup
-- Built-in best practices
-- AI-optimized workflows
-
-### Teams
-
-- Standardized workflows
-- Shared documentation patterns
-- Consistent CI/CD processes
-- Reduced onboarding time
-
-### Educational
-
-- Structured learning progression
-- Hands-on exercise framework
-- Reference material organization
-- Practice application templates
-
----
-
-## 📈 Success Metrics
-
-### Template Adoption
-
-- Projects created using templates
-- Time saved in project setup
-- Consistency across projects
-- User satisfaction ratings
-
-### Project Quality
-
-- Documentation completeness
-- Navigation effectiveness
-- Maintenance ease
-- Development velocity
-
----
-
-## 🎊 Key Achievements
-
-1. **Comprehensive Templates** - Complete project structures for both types
-2. **Best Practices Integration** - Learned from real project examples
-3. **Automation** - Interactive project generator with customization
-4. **Documentation Patterns** - Hub-and-spoke structure for navigation
-5. **Flexibility** - Templates adapt to different project needs
-6. **AI Optimization** - Structure designed for AI assistance
-
----
-
-## 📞 Support
-
-### Documentation
-
-- [Template Usage Guide](docs/TEMPLATE-USAGE.md)
-- [Project Types Guide](docs/PROJECT-TYPES.md)
-- [Best Practices Guide](docs/BEST-PRACTICES.md)
-
-### Examples
-
-- [Real Project Examples](admin/notes/examples/)
-- [Template Examples](templates/)
-
-### Issues
-
-- [GitHub Issues]([issues-url])
-- [Discussions]([discussions-url])
-
----
-
-## 📄 License
+## License
 
 [License information]
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 [![License](https://img.shields.io/github/license/grimm00/dev-infra)](LICENSE)
 
 **Purpose:** Standardized development infrastructure templates and best practices  
-**Version:** v0.7.0-dev  
-**Last Updated:** 2025-12-18  
+**Version:** v0.11.0  
+**Last Updated:** 2026-05-14  
 **Status:** ✅ Active
 
 ---
@@ -48,8 +48,8 @@ Each of these projects started from a dev-infra template and inherited the same 
 
 **Option A: Download Distribution (Recommended)**
 ```bash
-curl -L https://github.com/grimm00/dev-infra/releases/download/v0.6.0/dev-infra-0.6.0.tar.gz | tar -xz
-cd dev-infra-0.6.0
+curl -L https://github.com/grimm00/dev-infra/releases/download/v0.7.0/dev-infra-0.7.0.tar.gz | tar -xz
+cd dev-infra-0.7.0
 ```
 
 **Option B: Clone Repository**
@@ -136,7 +136,7 @@ Not all directories are required for every project. Templates are designed to be
 Dev-infra integrates with dev-toolkit for version-pinned template management:
 
 ```bash
-DEVINFRA_VERSION="0.6.0"
+DEVINFRA_VERSION="0.7.0"
 curl -L "https://github.com/grimm00/dev-infra/archive/v${DEVINFRA_VERSION}.tar.gz" | tar -xz
 ```
 
@@ -181,12 +181,6 @@ dev-infra/
 
 ---
 
-## License
-
-[License information]
-
----
-
-**Last Updated:** 2025-12-18  
+**Last Updated:** 2026-05-14  
 **Status:** ✅ Active  
 **Next:** [Template Usage Guide](docs/TEMPLATE-USAGE.md)

--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ Choose your project type:
 
 For applications, tools, services, and APIs. Includes hub-and-spoke documentation, feature-based planning, backend/frontend separation, centralized testing, and CI/CD workflows.
 
+<details>
+<summary>Template structure</summary>
+
 ```
 project/
 ├── docs/
@@ -98,9 +101,14 @@ project/
 └── .github/          # CI/CD workflows
 ```
 
+</details>
+
 ### Learning Project
 
 For tutorials, courses, and exercises. Uses stage-based progression from fundamentals through implementation, with reference materials and practice applications.
+
+<details>
+<summary>Template structure</summary>
 
 ```
 project/
@@ -112,6 +120,8 @@ project/
 └── docs/
     └── maintainers/      # Learning management
 ```
+
+</details>
 
 ---
 
@@ -167,6 +177,9 @@ See [Integration Guide](docs/INTEGRATION.md) for complete examples.
 
 ## Project Structure
 
+<details>
+<summary>Repository layout</summary>
+
 ```
 dev-infra/
 ├── templates/              # Project templates
@@ -178,6 +191,8 @@ dev-infra/
 │   └── services/           # Service-first organization
 └── .cursor/                # IDE configuration
 ```
+
+</details>
 
 ---
 

--- a/admin/feedback/sourcery/pr104.md
+++ b/admin/feedback/sourcery/pr104.md
@@ -1,0 +1,46 @@
+# Sourcery Review Analysis
+**PR**: #104
+**Repository**: grimm00/dev-infra
+**Generated**: Fri May 15 08:11:56 CDT 2026
+
+---
+
+## Summary
+
+Total Individual Comments: 0 + Overall Comments
+
+## Individual Comments
+
+## Overall Comments
+
+- The Quick Start section no longer shows a Windows-friendly download command; if Windows support is still expected, consider keeping or linking to a zip-based example so new users on Windows have a clear path.
+- You removed the Support/Issues section entirely; if GitHub Issues/Discussions are being used, it may be worth reintroducing a minimal section with the correct URLs so readers know where to go for help or bug reports.
+
+## Priority Matrix Assessment
+
+Use this template to assess each comment:
+
+| Comment | Priority | Impact | Effort | Action | Notes |
+|---------|----------|--------|--------|--------|-------|
+| Overall #1 (Windows download) | 🟢 LOW | 🟢 LOW | 🟢 LOW | Defer | Clone option covers Windows; no tar.gz assets exist for Windows anyway |
+| Overall #2 (Support/Issues section) | 🟡 MEDIUM | 🟡 MEDIUM | 🟢 LOW | Defer | Previous links were broken placeholders ([issues-url]); can add real links in a follow-up when URLs are confirmed |
+
+### Priority Levels
+- 🔴 **CRITICAL**: Security, stability, or core functionality issues
+- 🟠 **HIGH**: Bug risks or significant maintainability issues
+- 🟡 **MEDIUM**: Code quality and maintainability improvements
+- 🟢 **LOW**: Nice-to-have improvements
+
+### Impact Levels
+- 🔴 **CRITICAL**: Affects core functionality
+- 🟠 **HIGH**: User-facing or significant changes
+- 🟡 **MEDIUM**: Developer experience improvements
+- 🟢 **LOW**: Minor improvements
+
+### Effort Levels
+- 🟢 **LOW**: Simple, quick changes
+- 🟡 **MEDIUM**: Moderate complexity
+- 🟠 **HIGH**: Complex refactoring
+- 🔴 **VERY_HIGH**: Major rewrites
+
+

--- a/admin/services/meta/features/readme-narrative/planning/implementation-plan.md
+++ b/admin/services/meta/features/readme-narrative/planning/implementation-plan.md
@@ -54,7 +54,7 @@ Dev-infra's README currently reads as a product spec sheet — it describes what
 - [x] Task 3: Write downstream lineage section — projects produced by dev-infra patterns
 
 ### README Restructure
-- [ ] Task 4: Reorder README sections — origin/narrative before Quick Start
+- [x] Task 4: Reorder README sections — origin/narrative before Quick Start
 - [ ] Task 5: Consolidate redundant sections and reduce emoji-header noise
 - [ ] Task 6: Update stale references — version numbers, dates, placeholder links
 - [ ] Task 7: Make technical details secondary — collapsible or lower-priority positioning

--- a/admin/services/meta/features/readme-narrative/planning/implementation-plan.md
+++ b/admin/services/meta/features/readme-narrative/planning/implementation-plan.md
@@ -57,7 +57,7 @@ Dev-infra's README currently reads as a product spec sheet — it describes what
 - [x] Task 4: Reorder README sections — origin/narrative before Quick Start
 - [x] Task 5: Consolidate redundant sections and reduce emoji-header noise
 - [x] Task 6: Update stale references — version numbers, dates, placeholder links
-- [ ] Task 7: Make technical details secondary — collapsible or lower-priority positioning
+- [x] Task 7: Make technical details secondary — collapsible or lower-priority positioning
 
 ### Start.txt Reconciliation
 - [ ] Task 8: Fill in start.txt with actual dev-infra project context

--- a/admin/services/meta/features/readme-narrative/planning/implementation-plan.md
+++ b/admin/services/meta/features/readme-narrative/planning/implementation-plan.md
@@ -55,7 +55,7 @@ Dev-infra's README currently reads as a product spec sheet — it describes what
 
 ### README Restructure
 - [x] Task 4: Reorder README sections — origin/narrative before Quick Start
-- [ ] Task 5: Consolidate redundant sections and reduce emoji-header noise
+- [x] Task 5: Consolidate redundant sections and reduce emoji-header noise
 - [ ] Task 6: Update stale references — version numbers, dates, placeholder links
 - [ ] Task 7: Make technical details secondary — collapsible or lower-priority positioning
 

--- a/admin/services/meta/features/readme-narrative/planning/implementation-plan.md
+++ b/admin/services/meta/features/readme-narrative/planning/implementation-plan.md
@@ -56,7 +56,7 @@ Dev-infra's README currently reads as a product spec sheet — it describes what
 ### README Restructure
 - [x] Task 4: Reorder README sections — origin/narrative before Quick Start
 - [x] Task 5: Consolidate redundant sections and reduce emoji-header noise
-- [ ] Task 6: Update stale references — version numbers, dates, placeholder links
+- [x] Task 6: Update stale references — version numbers, dates, placeholder links
 - [ ] Task 7: Make technical details secondary — collapsible or lower-priority positioning
 
 ### Start.txt Reconciliation

--- a/admin/services/meta/features/readme-narrative/planning/status-and-next-steps.md
+++ b/admin/services/meta/features/readme-narrative/planning/status-and-next-steps.md
@@ -7,12 +7,12 @@
 
 ## 📊 Progress Summary
 
-**Overall:** 4/9 tasks complete
+**Overall:** 5/9 tasks complete
 
 | Group | Status | Progress | Notes |
 |-------|--------|----------|-------|
 | Origin Narrative Content | ✅ Complete | 3/3 tasks | |
-| README Restructure | 🟠 In Progress | 1/4 tasks | |
+| README Restructure | 🟠 In Progress | 2/4 tasks | |
 | Start.txt Reconciliation | 🔴 Not Started | 0/2 tasks | |
 
 ---

--- a/admin/services/meta/features/readme-narrative/planning/status-and-next-steps.md
+++ b/admin/services/meta/features/readme-narrative/planning/status-and-next-steps.md
@@ -7,12 +7,12 @@
 
 ## 📊 Progress Summary
 
-**Overall:** 3/9 tasks complete
+**Overall:** 4/9 tasks complete
 
 | Group | Status | Progress | Notes |
 |-------|--------|----------|-------|
 | Origin Narrative Content | ✅ Complete | 3/3 tasks | |
-| README Restructure | 🔴 Not Started | 0/4 tasks | |
+| README Restructure | 🟠 In Progress | 1/4 tasks | |
 | Start.txt Reconciliation | 🔴 Not Started | 0/2 tasks | |
 
 ---

--- a/admin/services/meta/features/readme-narrative/planning/status-and-next-steps.md
+++ b/admin/services/meta/features/readme-narrative/planning/status-and-next-steps.md
@@ -7,12 +7,12 @@
 
 ## 📊 Progress Summary
 
-**Overall:** 5/9 tasks complete
+**Overall:** 6/9 tasks complete
 
 | Group | Status | Progress | Notes |
 |-------|--------|----------|-------|
 | Origin Narrative Content | ✅ Complete | 3/3 tasks | |
-| README Restructure | 🟠 In Progress | 2/4 tasks | |
+| README Restructure | 🟠 In Progress | 3/4 tasks | |
 | Start.txt Reconciliation | 🔴 Not Started | 0/2 tasks | |
 
 ---

--- a/admin/services/meta/features/readme-narrative/planning/status-and-next-steps.md
+++ b/admin/services/meta/features/readme-narrative/planning/status-and-next-steps.md
@@ -7,12 +7,12 @@
 
 ## 📊 Progress Summary
 
-**Overall:** 6/9 tasks complete
+**Overall:** 7/9 tasks complete
 
 | Group | Status | Progress | Notes |
 |-------|--------|----------|-------|
 | Origin Narrative Content | ✅ Complete | 3/3 tasks | |
-| README Restructure | 🟠 In Progress | 3/4 tasks | |
+| README Restructure | ✅ Complete | 4/4 tasks | |
 | Start.txt Reconciliation | 🔴 Not Started | 0/2 tasks | |
 
 ---

--- a/admin/services/meta/features/readme-narrative/planning/tasks/02-readme-restructure.md
+++ b/admin/services/meta/features/readme-narrative/planning/tasks/02-readme-restructure.md
@@ -2,7 +2,8 @@
 
 **Feature:** README Narrative
 **Group:** README Restructure
-**Status:** 🟠 In Progress
+**Status:** ✅ Complete
+**Completed:** 2026-05-14
 **Last Updated:** 2026-05-14
 
 > ⚠️ **Scaffolding only.** Run write-plan **Expand** on this group to generate detailed steps and acceptance criteria.
@@ -23,7 +24,7 @@
   - Version references (v0.6.0 in curl commands, v0.7.0-dev in header), last-updated date (2025-12-18), placeholder links ([issues-url], [discussions-url]), template statistics counts
   - Deliverable: All references reflect current project state
 
-- [ ] Task 7: Make technical details secondary — collapsible or lower-priority positioning
+- [x] Task 7: Make technical details secondary — collapsible or lower-priority positioning
   - Template structures, technology stack, statistics, and use cases sections currently dominate; consider collapsible details or moving below fold
   - Deliverable: Technical reference material accessible but not primary
 

--- a/admin/services/meta/features/readme-narrative/planning/tasks/02-readme-restructure.md
+++ b/admin/services/meta/features/readme-narrative/planning/tasks/02-readme-restructure.md
@@ -19,7 +19,7 @@
   - Current README has duplicate "Getting Started" (lines 53 and 213), redundant "Development" section that restates project structure, and heavy emoji usage that reads as filler
   - Deliverable: Leaner README with no duplicated content
 
-- [ ] Task 6: Update stale references — version numbers, dates, placeholder links
+- [x] Task 6: Update stale references — version numbers, dates, placeholder links
   - Version references (v0.6.0 in curl commands, v0.7.0-dev in header), last-updated date (2025-12-18), placeholder links ([issues-url], [discussions-url]), template statistics counts
   - Deliverable: All references reflect current project state
 

--- a/admin/services/meta/features/readme-narrative/planning/tasks/02-readme-restructure.md
+++ b/admin/services/meta/features/readme-narrative/planning/tasks/02-readme-restructure.md
@@ -2,7 +2,7 @@
 
 **Feature:** README Narrative
 **Group:** README Restructure
-**Status:** 🔴 Scaffolding (needs expansion)
+**Status:** 🟠 In Progress
 **Last Updated:** 2026-05-14
 
 > ⚠️ **Scaffolding only.** Run write-plan **Expand** on this group to generate detailed steps and acceptance criteria.
@@ -11,7 +11,7 @@
 
 ## 📝 Tasks
 
-- [ ] Task 4: Reorder README sections — origin/narrative before Quick Start
+- [x] Task 4: Reorder README sections — origin/narrative before Quick Start
   - Move or insert origin content above the Quick Start section; current structure jumps from badges to installation
   - Deliverable: README leads with purpose and context before mechanics
 

--- a/admin/services/meta/features/readme-narrative/planning/tasks/02-readme-restructure.md
+++ b/admin/services/meta/features/readme-narrative/planning/tasks/02-readme-restructure.md
@@ -15,7 +15,7 @@
   - Move or insert origin content above the Quick Start section; current structure jumps from badges to installation
   - Deliverable: README leads with purpose and context before mechanics
 
-- [ ] Task 5: Consolidate redundant sections and reduce emoji-header noise
+- [x] Task 5: Consolidate redundant sections and reduce emoji-header noise
   - Current README has duplicate "Getting Started" (lines 53 and 213), redundant "Development" section that restates project structure, and heavy emoji usage that reads as filler
   - Deliverable: Leaner README with no duplicated content
 


### PR DESCRIPTION
## Summary

- Remove 7 redundant/duplicate sections (What is Dev-Infra, second Getting Started, Technology Stack, Template Statistics, Use Cases, Success Metrics, Key Achievements) — README reduced from 435 to ~200 lines
- Strip emoji prefixes from all section headers for cleaner presentation
- Update stale version references: v0.7.0-dev → v0.11.0, download URLs v0.6.0 → v0.7.0, dates 2025-12-18 → 2026-05-14
- Wrap template structure trees and project structure in collapsible `<details>` tags so narrative content dominates the page
- Remove placeholder License section and broken `[issues-url]`/`[discussions-url]` links

## Why

PR #103 added narrative content (origin story, identity pivot, lineage) to the README but left the existing product-spec structure intact. The result was a 435-line README where the new narrative competed with duplicate sections, stale references, and emoji-heavy headers. This PR completes the restructure planned in Group 2 of the readme-narrative feature (Tasks 4–7).

## After Merge

No downstream effects — docs-only change. The README is shorter, leads with narrative, and has current version references. Template structures are still accessible via collapsible sections.

## Follow-ups

- Tasks 8–9 (Group 3: Start.txt Reconciliation) remain — fill in start.txt with actual project context and ensure consistency with the README origin section.