### PR TITLE
feat(skill-template-separation): expected_skills Manifest in Templates (Group 4)

### DIFF
--- a/admin/feedback/deferred-tasks.md
+++ b/admin/feedback/deferred-tasks.md
@@ -2,7 +2,7 @@
 
 **Purpose:** Collection of medium and low priority tasks/opportunities identified in PR reviews that have been deferred for future work  
 **Status:** 📋 Active Backlog  
-**Last Updated:** 2026-06-04
+**Last Updated:** 2026-06-08
 
 ---
 
@@ -635,3 +635,13 @@ This document tracks all medium (🟡) and low (🟢) priority tasks identified 
 - ~~**PR108-Inline-#1 (🟢 LOW, 🟢 LOW effort):** Plural agreement typo "Task 11–12 addresses" → "Tasks 11–12 address" in `plan-review-2026-06-04.md`~~ — ✅ Fixed inline.
 - ~~**PR108-Overall-#1 (🟢 LOW, 🟢 LOW effort):** Completion criteria in `tasks/03-template-sync-manifest-retirement.md` said "removed or minimized" but ADR-001 FR-BNDL-4 requires full retirement; language tightened to remove the partial-retention hedge~~ — ✅ Fixed inline.
 - **PR108-Overall-#2 (🟢 LOW, 🟡 MEDIUM effort):** Duplicate `**Last Updated:**` lines (top metadata block + trailing line) in `tasks/03-template-sync-manifest-retirement.md`. This is a *project-wide convention pattern* — the same duplication exists across all 6 task docs in this feature (`01-…md` through `06-…md`) and likely the broader template scaffold. Fixing in isolation here would create inconsistency. Right intervention is a convention discussion: pick one source of truth (top metadata vs trailing line), sweep all task docs in a separate chore PR.
+
+---
+
+## PR #109 Additions
+
+**Date:** 2026-06-08
+**Status:** Sourcery triaged (0 inline + 2 overall; 1 fixed inline, 1 deferred)
+
+- ~~**PR109-Overall-#1 (🟡 MEDIUM, 🟢 LOW effort):** The 13-skill `expected_skills` inventory is duplicated across `docs/DEV-INFRA-YML.md` and both template `.dev-infra.yml` files~~ — ✅ Fixed inline. Both template `.dev-infra.yml` headers now name `docs/DEV-INFRA-YML.md` as the canonical inventory with a sync reminder. Full single-source generation deferred until `new-project.sh` / proj-cli can inject the list (see Group 5).
+- **PR109-Overall-#2 (🟢 LOW, 🟡 MEDIUM effort):** Template README links to the `.dev-infra.yml` schema via an absolute GitHub URL pinned to `develop` rather than a relative/docs-hub link. **Deferred intentionally:** template READMEs ship into standalone generated projects that do *not* contain dev-infra's `docs/` tree, so a relative in-repo link would break post-generation. The external link is the correct default; the branch-pinned-URL tradeoff is flagged for the Group 6 documentation sweep, which may introduce a project-local docs-hub link pattern.

--- a/admin/feedback/sourcery/pr109.md
+++ b/admin/feedback/sourcery/pr109.md
@@ -1,0 +1,25 @@
+# Sourcery Review Analysis
+**PR**: #109
+**Repository**: grimm00/dev-infra
+**Generated**: 2026-06-05 (group-cycle agent)
+
+---
+
+## Summary
+
+Sourcery did not land within the Step 4 polling window (4 attempts × 15s after initial wait). GitHub check remained `pending` at validation time. CI checks (`quick-checks`, `full-tests-ubuntu`, `full-tests-macos`, `build-image`) reported **pass**.
+
+Total Individual Comments: 0
+Total Overall Comments: 0
+
+---
+
+## Priority Matrix Assessment
+
+| Comment | Priority | Impact | Effort | Action |
+|---------|----------|--------|--------|--------|
+| *(none — review not available)* | — | — | — | — |
+
+---
+
+**Note:** Re-run `dt-review 109 admin/feedback/sourcery/pr109.md` after Sourcery completes if inline feedback arrives post-validation.

--- a/admin/feedback/sourcery/pr109.md
+++ b/admin/feedback/sourcery/pr109.md
@@ -1,25 +1,40 @@
 # Sourcery Review Analysis
 **PR**: #109
 **Repository**: grimm00/dev-infra
-**Generated**: 2026-06-05 (group-cycle agent)
+**Generated**: Fri Jun  5 14:07:30 CDT 2026
 
 ---
 
 ## Summary
 
-Sourcery did not land within the Step 4 polling window (4 attempts × 15s after initial wait). GitHub check remained `pending` at validation time. CI checks (`quick-checks`, `full-tests-ubuntu`, `full-tests-macos`, `build-image`) reported **pass**.
+Total Individual Comments: 0 + 2 Overall Comments
 
-Total Individual Comments: 0
-Total Overall Comments: 0
+## Individual Comments
 
----
+*(none)*
+
+## Overall Comments
+
+- The 13-skill `expected_skills` inventory is now duplicated across `docs/DEV-INFRA-YML.md` and both template `.dev-infra.yml` files; consider centralizing this list (or at least explicitly referencing the doc from the YAML comments) to reduce the risk of drift when the corpus changes.
+- The template README links to the `.dev-infra.yml` schema using an absolute GitHub URL to the `develop` branch; using a relative link into this repo (or a docs hub link) would make the reference more robust to forks and branch renames.
 
 ## Priority Matrix Assessment
 
 | Comment | Priority | Impact | Effort | Action |
 |---------|----------|--------|--------|--------|
-| *(none — review not available)* | — | — | — | — |
+| Overall-#1 (duplicated 13-skill list across doc + template YAML) | 🟡 MEDIUM | 🟡 MEDIUM | 🟢 LOW | ✅ Fixed inline — YAML header comments now point to `docs/DEV-INFRA-YML.md` as canonical inventory with sync note |
+| Overall-#2 (absolute GitHub URL in template README) | 🟢 LOW | 🟢 LOW | 🟡 MEDIUM | Deferred — generated projects lack in-repo docs; external link intentional. README prose clarified; future Group 6 may add project-local docs hub link pattern |
 
----
+### Overall-#1: Duplicated skill inventory
 
-**Note:** Re-run `dt-review 109 admin/feedback/sourcery/pr109.md` after Sourcery completes if inline feedback arrives post-validation.
+**Verdict — ✅ Fixed inline.** Strengthened `.dev-infra.yml` file headers in both templates to name `docs/DEV-INFRA-YML.md` as the canonical inventory and remind maintainers to keep copies in sync. Full single-source generation deferred until `new-project.sh` / proj-cli can inject lists.
+
+### Overall-#2: Absolute GitHub URL in template README
+
+**Verdict — Deferred.** Template READMEs ship into standalone generated projects that do not contain dev-infra's `docs/` tree — a relative in-repo link would break post-generation. Kept external link; clarified maintainer vs generated-project audience in README bullet. Branch-pinned URL tradeoff noted for Group 6 docs sweep.
+
+### Priority Levels (reference)
+- 🔴 **CRITICAL**: Security, stability, or core functionality issues
+- 🟠 **HIGH**: Bug risks or significant maintainability issues
+- 🟡 **MEDIUM**: Code quality and maintainability improvements
+- 🟢 **LOW**: Nice-to-have improvements

--- a/admin/services/meta/features/skill-template-separation/planning/implementation-plan.md
+++ b/admin/services/meta/features/skill-template-separation/planning/implementation-plan.md
@@ -31,7 +31,7 @@ tasks_files:
 
 **Status:** 🟠 In Progress
 **Created:** 2026-05-22
-**Last Updated:** 2026-06-04
+**Last Updated:** 2026-06-05
 **Source:** [decisions/adr-001-separation-model.md](../decisions/adr-001-separation-model.md)
 
 ---
@@ -86,10 +86,10 @@ This plan covers ADR-001 only. ADR-002 (installation architecture / symlinks) an
 - [x] Task 14: Remove related CI workflow steps that consume the manifest
 
 ### expected_skills Manifest in Templates
-- [ ] Task 15: Define `expected_skills` field schema in `.dev-infra.yml`
-- [ ] Task 16: Populate `expected_skills` in `templates/standard-project/.dev-infra.yml`
-- [ ] Task 17: Populate `expected_skills` in `templates/learning-project/.dev-infra.yml`
-- [ ] Task 18: Document the field in template README and `.dev-infra.yml` reference docs
+- [x] Task 15: Define `expected_skills` field schema in `.dev-infra.yml`
+- [x] Task 16: Populate `expected_skills` in `templates/standard-project/.dev-infra.yml`
+- [x] Task 17: Populate `expected_skills` in `templates/learning-project/.dev-infra.yml`
+- [x] Task 18: Document the field in template README and `.dev-infra.yml` reference docs
 
 ### proj-cli Validation
 - [ ] Task 19: Design `proj-cli` `expected_skills` validation step (warn-not-error)
@@ -106,7 +106,7 @@ This plan covers ADR-001 only. ADR-002 (installation architecture / symlinks) an
 
 ## ✅ Definition of Done
 
-- [ ] All 25 tasks complete (14/25 done; Groups 1–3 ✅)
+- [ ] All 25 tasks complete (18/25 done; Groups 1–4 ✅)
 - [x] CI passes on the new feature branch (demonstrated on PRs #106, #107, #108)
 - [ ] Generated project (via `./scripts/new-project.sh`) contains no bundled skills/commands/agents — pending Group 4 + 5 validation work
 - [ ] `proj-cli` setup warns (not errors) when expected skills are missing — pending Group 5

--- a/admin/services/meta/features/skill-template-separation/planning/plan-review-2026-06-05.md
+++ b/admin/services/meta/features/skill-template-separation/planning/plan-review-2026-06-05.md
@@ -1,0 +1,66 @@
+# Plan Review — Skill-Template Separation (Group 4)
+
+**Feature:** skill-template-separation  
+**Planning root:** `admin/services/meta/features/skill-template-separation/planning/`  
+**Status:** ✅ Ready  
+**Reviewed:** 2026-06-05  
+**Scope:** Group 4 only (Tasks 15–18)
+
+---
+
+## 📋 Plan Structure
+
+- [x] Implementation plan found and parseable
+- [x] Group 4 task file exists (`tasks/04-expected-skills-manifest.md`)
+- [x] Checkbox census: Groups 1–3 complete (14/25); Group 4 pending (0/4)
+- [x] Prior group PR #108 merged to `develop` (2026-06-04); post-PR docs landed in `cc5d82d`
+
+---
+
+## 📝 Task Group Review
+
+### Group 4: expected_skills Manifest in Templates (Tasks 15–18)
+
+- **Header status:** Scaffolding — expansion required in this cycle
+- **Task count:** 4 (within 2–8 band)
+- **Descriptions:** Schema → populate standard → populate learning → document
+- **Dependencies section:** Groups 2–3 complete; `.dev-infra.yml` files do not yet exist in templates (greenfield for this group)
+
+---
+
+## 🔗 Dependency Validation
+
+- [x] Group 2 prerequisite satisfied (bundled skills/commands removed from templates)
+- [x] Group 3 prerequisite satisfied (template-sync-manifest retired; CI green on `develop`)
+- [x] Group 5 correctly deferred — proj-cli validation requires manifest field from Group 4 first
+- [x] No circular dependencies
+
+---
+
+## 🔄 Consistency Check
+
+- [x] Plan ↔ Status progress counts align (14/25, Group 4 next)
+- [x] Task 16 bullet list matches former bundled skill dirs from PR #107 (13 skills under `.claude/skills/`)
+- [x] Learning template had commands only (no bundled skills tree) — Task 17 should mirror standard list for workflow parity
+- [x] `new-project.sh` does not yet substitute `.dev-infra.yml` placeholders — acceptable; file ships as template artifact until proj-cli/generator work
+
+---
+
+## 🔴 Blockers
+
+*(none)*
+
+---
+
+## 🟡 Warnings
+
+- **Template README stale prose:** Both template READMEs still describe commands under `.cursor/commands/` — broader refresh deferred to Group 6; Group 4 adds `.dev-infra.yml` / `expected_skills` section only.
+- **Identifier convention open in scaffold:** Task 15 must record bare-name vs namespaced choice before Group 5 implements lookup.
+
+---
+
+## ✅ Readiness Assessment
+
+**Verdict:** ✅ Ready to execute Group 4 on `feat/skill-template-separation-04-expected-skills-manifest`.
+
+**Next:** Expand task file → define schema + `docs/DEV-INFRA-YML.md` → add template `.dev-infra.yml` files → document in template READMEs and `docs/TEMPLATE-FILES.md`.

--- a/admin/services/meta/features/skill-template-separation/planning/status-and-next-steps.md
+++ b/admin/services/meta/features/skill-template-separation/planning/status-and-next-steps.md
@@ -1,20 +1,20 @@
 # Status & Next Steps — Skill-Template Separation (ADR-001)
 
 **Status:** 🟠 In Progress
-**Last Updated:** 2026-06-04
+**Last Updated:** 2026-06-05
 
 ---
 
 ## 📊 Progress Summary
 
-**Overall:** 14/25 tasks complete
+**Overall:** 18/25 tasks complete
 
 | Group | Status | Progress | Notes |
 |-------|--------|----------|-------|
 | Branch Setup & Doc Curation | ✅ Complete | 5/5 tasks | Merged PR #106 (2026-06-03) |
 | Template Cleanup | ✅ Complete | 5/5 tasks | Merged PR #107 (2026-06-03); 82 bundled files removed |
 | Template-Sync-Manifest Retirement | ✅ Complete | 4/4 tasks | Merged PR #108 (2026-06-04); `develop` Run Tests confirmed green post-merge |
-| expected_skills Manifest in Templates | 🔴 Not Started | 0/4 tasks | New `.dev-infra.yml` field |
+| expected_skills Manifest in Templates | 🟠 In Progress | 4/4 tasks | PR pending — `.dev-infra.yml` + `docs/DEV-INFRA-YML.md` |
 | proj-cli Validation | 🔴 Not Started | 0/4 tasks | Warn-not-error behavior |
 | Documentation & Supersession | 🔴 Not Started | 0/3 tasks | global-command-distribution superseded; AGENTS.md updated |
 
@@ -22,7 +22,7 @@
 
 ## 🚀 Next Steps
 
-1. **Group 4:** `expected_skills` manifest in templates (`.dev-infra.yml` field, both templates, docs).
+1. **Merge Group 4 PR** — `expected_skills` manifest in templates.
 2. **Group 5:** `proj-cli` validation (warn-not-error on missing expected skills).
 3. **Group 6:** Documentation & supersession (mark `global-command-distribution` superseded, update AGENTS.md, cross-link from four-arm-architecture).
 
@@ -33,7 +33,8 @@
 - Plan generated from `decisions/adr-001-separation-model.md` on 2026-05-22.
 - **Doc surface intent:** ADR-001 + planning tree on `develop`; research on `docs/skill-template-separation-research`.
 - ADR-002 and ADR-003 out of scope for this plan.
-- **CI:** Green on `develop` as of PR #108 merge (Run Tests `success` at 2026-06-04T16:40:38Z); the post-#107 red is healed.
+- **CI:** Green on `develop` as of PR #108 merge (Run Tests `success` at 2026-06-04T16:40:38Z).
+- **Group 4:** Bare skill identifiers chosen for `expected_skills` (matches `~/.cursor/skills/<name>/` layout); 13 entries mirror pre-#107 bundled corpus.
 
 ## 🧭 Decisions Made
 
@@ -41,6 +42,7 @@
 - **Group 1 merge:** PR #106 landed ADR-001 + planning tree on `develop` (2026-06-03).
 - **Group 2 merge:** PR #107 removed bundled template tooling; absence Bats added (2026-06-03). Merged with admin override on `validate-template-sync` failure, contingent on Group 3 landing the fix.
 - **Group 3 merge:** PR #108 retired `template-sync-manifest.txt`, `validate-template-sync.sh`, dedicated Bats suite, and the CI workflow step that invoked them (2026-06-04). `develop` Run Tests confirmed green post-merge — Group 2's admin override is now resolved.
+- **Group 4 identifier convention (Task 15):** Bare skill directory names (not namespaced) for `expected_skills` v1.
 
 ## 📋 Deferred
 
@@ -53,4 +55,4 @@
 
 ---
 
-**Last Updated:** 2026-06-04
+**Last Updated:** 2026-06-05

--- a/admin/services/meta/features/skill-template-separation/planning/tasks/04-expected-skills-manifest.md
+++ b/admin/services/meta/features/skill-template-separation/planning/tasks/04-expected-skills-manifest.md
@@ -2,27 +2,130 @@
 
 **Feature:** Skill-Template Separation (ADR-001)
 **Group:** expected_skills Manifest in Templates
-**Status:** 🔴 Scaffolding (needs expansion)
-**Last Updated:** 2026-05-22
+**Status:** ✅ Expanded
+**Last Updated:** 2026-06-05
 
-> ⚠️ Scaffolding only — run `write-plan-expand` on this file to flesh out steps and acceptance criteria.
+---
+
+## 📌 Operating Context
+
+ADR-001 FR-BNDL-2: `.dev-infra.yml` declares skill expectations; templates carry **no bundled copies**. Group 4 introduces the `expected_skills` field, populates both templates, and documents the schema. Group 5 adds proj-cli warn-not-error validation; Group 6 refreshes broader AGENTS.md / stale command prose.
+
+**Identifier convention (Task 15 decision):** **Bare skill directory names** (e.g. `explore`, not `ai-workflow/explore`). Matches global install layout (`~/.cursor/skills/<name>/` or `~/.claude/skills/<name>/`) and Task 19 design notes in Group 5.
+
+**Skill inventory source:** 13 skills formerly bundled under `templates/standard-project/.claude/skills/` (removed PR #107): `commit`, `decision`, `discuss`, `explore`, `handoff`, `int-opp`, `narrative`, `plan-review`, `pre-commit-review`, `reflect`, `research`, `spike`, `write-plan`.
 
 ---
 
 ## 📝 Tasks
 
 - [ ] Task 15: Define `expected_skills` field schema in `.dev-infra.yml`
-  - Add a top-level `expected_skills:` list (strings of skill identifiers) to the `.dev-infra.yml` schema.
-  - Decide: bare names (`explore`) or namespaced (`ai-workflow/explore`)? Document the choice.
-
 - [ ] Task 16: Populate `expected_skills` in `templates/standard-project/.dev-infra.yml`
-  - List the skills the standard template's AGENTS.md and conventions assume (explore, research, write-plan, decision, commit, pre-commit-review, handoff, etc.).
-
 - [ ] Task 17: Populate `expected_skills` in `templates/learning-project/.dev-infra.yml`
-  - Mirror the standard list, adjusting for any learning-template-specific assumptions.
-
 - [ ] Task 18: Document the field in template README and `.dev-infra.yml` reference docs
-  - Explain the field's purpose, format, and `proj-cli` validation behavior.
+
+### Task 15: Define `expected_skills` field schema in `.dev-infra.yml`
+
+**Purpose:** Formalize FR-BNDL-2 so templates and proj-cli share one contract.
+
+**Steps:**
+
+1. Create authoritative reference: `docs/DEV-INFRA-YML.md` with:
+   - File location (project root `.dev-infra.yml`)
+   - Existing metadata fields (`template`, `version`, `created`) from template-metadata research
+   - **`expected_skills`** field: type `list[string]`, bare identifiers, sorted alphabetically recommended
+   - Validation semantics: proj-cli warns (never errors) when a listed skill is not installed (Group 5 implements)
+2. Document bare-name rationale and rejected namespaced alternative in the reference doc.
+3. Add `docs/DEV-INFRA-YML.md` to `docs/README.md` Quick Links.
+
+**Files:**
+
+- `docs/DEV-INFRA-YML.md` (new)
+- `docs/README.md` (link)
+
+**Acceptance:**
+
+- Schema documents `expected_skills` type, format, and identifier convention
+- Bare names chosen and documented with rationale
+- Reference doc linked from docs hub
+
+---
+
+### Task 16: Populate `expected_skills` in `templates/standard-project/.dev-infra.yml`
+
+**Purpose:** Ship the manifest in the standard-project template product.
+
+**Steps:**
+
+1. Create `templates/standard-project/.dev-infra.yml` with:
+   ```yaml
+   template: standard-project
+   version: "[DEV_INFRA_VERSION]"
+   created: "[CREATED_DATE]"
+   expected_skills:
+     # 13 entries — alphabetical, bare names (see docs/DEV-INFRA-YML.md)
+   ```
+2. Populate all 13 skill identifiers from Operating Context inventory.
+3. Verify YAML parses: `python3 -c "import yaml; yaml.safe_load(open('templates/standard-project/.dev-infra.yml'))"`
+
+**Files:**
+
+- `templates/standard-project/.dev-infra.yml` (new)
+
+**Acceptance:**
+
+- File exists with `expected_skills` list of 13 bare identifiers
+- `template:` matches `standard-project`
+- YAML valid
+
+---
+
+### Task 17: Populate `expected_skills` in `templates/learning-project/.dev-infra.yml`
+
+**Purpose:** Mirror standard manifest — learning template uses the same workflow commands/skills (no separate bundled skill tree existed pre-#107).
+
+**Steps:**
+
+1. Create `templates/learning-project/.dev-infra.yml` with `template: learning-project` and the **same** `expected_skills` list as Task 16.
+2. Verify YAML parses.
+
+**Files:**
+
+- `templates/learning-project/.dev-infra.yml` (new)
+
+**Acceptance:**
+
+- File exists; `expected_skills` matches standard-project list
+- `template:` matches `learning-project`
+
+---
+
+### Task 18: Document the field in template README and `.dev-infra.yml` reference docs
+
+**Purpose:** Orient users and maintainers on manifest purpose and proj-cli behavior.
+
+**Steps:**
+
+1. Add **Project Metadata (`.dev-infra.yml`)** section to both template READMEs:
+   - Purpose of the file
+   - Link to dev-infra `docs/DEV-INFRA-YML.md` (relative path from generated project context: document as "see dev-infra documentation" or copy reference into project docs if needed — use hub link pattern)
+   - Note that skills install globally; `expected_skills` is a manifest, not a bundle
+   - Mention proj-cli will warn on missing skills (Group 5)
+2. Update `docs/TEMPLATE-FILES.md` — add `.dev-infra.yml` under Configuration Files for both templates.
+3. Cross-link: `docs/DEV-INFRA-YML.md` ↔ `docs/TEMPLATE-FILES.md`.
+
+**Files:**
+
+- `templates/standard-project/README.md`
+- `templates/learning-project/README.md`
+- `docs/TEMPLATE-FILES.md`
+- `docs/DEV-INFRA-YML.md` (cross-links from Task 15)
+
+**Acceptance:**
+
+- Both template READMEs describe `.dev-infra.yml` and `expected_skills`
+- `docs/TEMPLATE-FILES.md` documents the file
+- Cross-links resolve within repo
 
 ---
 
@@ -42,6 +145,17 @@
 
 ---
 
+## 📊 Progress Tracking
+
+| Task | Status | Notes |
+|------|--------|-------|
+| Task 15: Schema | 🔴 Not Started | |
+| Task 16: standard-project | 🔴 Not Started | |
+| Task 17: learning-project | 🔴 Not Started | |
+| Task 18: Documentation | 🔴 Not Started | |
+
+---
+
 ## 🔗 Dependencies
 
 - Group 2 (Template Cleanup) — populates the manifest only after the bundled skills are gone.
@@ -49,4 +163,4 @@
 
 ---
 
-**Last Updated:** 2026-05-22
+**Last Updated:** 2026-06-05

--- a/admin/services/meta/features/skill-template-separation/planning/tasks/04-expected-skills-manifest.md
+++ b/admin/services/meta/features/skill-template-separation/planning/tasks/04-expected-skills-manifest.md
@@ -2,7 +2,7 @@
 
 **Feature:** Skill-Template Separation (ADR-001)
 **Group:** expected_skills Manifest in Templates
-**Status:** ✅ Expanded
+**Status:** ✅ Complete
 **Last Updated:** 2026-06-05
 
 ---
@@ -19,10 +19,10 @@ ADR-001 FR-BNDL-2: `.dev-infra.yml` declares skill expectations; templates carry
 
 ## 📝 Tasks
 
-- [ ] Task 15: Define `expected_skills` field schema in `.dev-infra.yml`
-- [ ] Task 16: Populate `expected_skills` in `templates/standard-project/.dev-infra.yml`
-- [ ] Task 17: Populate `expected_skills` in `templates/learning-project/.dev-infra.yml`
-- [ ] Task 18: Document the field in template README and `.dev-infra.yml` reference docs
+- [x] Task 15: Define `expected_skills` field schema in `.dev-infra.yml`
+- [x] Task 16: Populate `expected_skills` in `templates/standard-project/.dev-infra.yml`
+- [x] Task 17: Populate `expected_skills` in `templates/learning-project/.dev-infra.yml`
+- [x] Task 18: Document the field in template README and `.dev-infra.yml` reference docs
 
 ### Task 15: Define `expected_skills` field schema in `.dev-infra.yml`
 
@@ -139,9 +139,9 @@ ADR-001 FR-BNDL-2: `.dev-infra.yml` declares skill expectations; templates carry
 
 ## ✅ Completion Criteria
 
-- [ ] Schema updated and documented
-- [ ] Both templates' `.dev-infra.yml` files contain the field with realistic entries
-- [ ] Reference docs updated; cross-linked from template READMEs
+- [x] Schema updated and documented
+- [x] Both templates' `.dev-infra.yml` files contain the field with realistic entries
+- [x] Reference docs updated; cross-linked from template READMEs
 
 ---
 
@@ -149,10 +149,10 @@ ADR-001 FR-BNDL-2: `.dev-infra.yml` declares skill expectations; templates carry
 
 | Task | Status | Notes |
 |------|--------|-------|
-| Task 15: Schema | 🔴 Not Started | |
-| Task 16: standard-project | 🔴 Not Started | |
-| Task 17: learning-project | 🔴 Not Started | |
-| Task 18: Documentation | 🔴 Not Started | |
+| Task 15: Schema | ✅ Complete | docs/DEV-INFRA-YML.md |
+| Task 16: standard-project | ✅ Complete | 13 bare identifiers |
+| Task 17: learning-project | ✅ Complete | mirrors standard list |
+| Task 18: Documentation | ✅ Complete | READMEs + TEMPLATE-FILES |
 
 ---
 

--- a/docs/DEV-INFRA-YML.md
+++ b/docs/DEV-INFRA-YML.md
@@ -1,0 +1,124 @@
+# .dev-infra.yml Reference
+
+**Purpose:** Schema reference for the per-project dev-infra metadata file  
+**Status:** ✅ Active  
+**Last Updated:** 2026-06-05
+
+---
+
+## Overview
+
+Every project generated from a dev-infra template includes a **`.dev-infra.yml`** file at the repository root. The file records which template produced the project, which dev-infra version was used, and — per [ADR-001](../admin/services/meta/features/skill-template-separation/decisions/adr-001-separation-model.md) — which **skills the template workflow assumes** via the `expected_skills` manifest.
+
+Templates do **not** bundle skill copies. The manifest tells `proj-cli` (and humans) which globally installed skills align with the template's planning and workflow conventions.
+
+**Related:** [Template Files Guide](TEMPLATE-FILES.md) · [Skill-Template Separation ADR-001](../admin/services/meta/features/skill-template-separation/decisions/adr-001-separation-model.md)
+
+---
+
+## File Location
+
+| Property | Value |
+|----------|-------|
+| **Path** | `.dev-infra.yml` (project root) |
+| **Format** | YAML |
+| **Checked in** | Yes — version-controlled project metadata |
+
+---
+
+## Schema (v1)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `template` | string | Yes | Template type: `standard-project` or `learning-project` |
+| `version` | string | Yes | dev-infra version used at project generation (semver) |
+| `created` | string (date) | Recommended | ISO date (`YYYY-MM-DD`) when the project was generated |
+| `expected_skills` | list[string] | Yes (ADR-001) | Bare skill identifiers the template workflow assumes |
+
+Future fields (`last_sync`, `sync`, `customizations`) may be added when template sync features land — see [template-metadata research](../admin/services/template-generation/features/template-metadata/research/research-essential-fields.md).
+
+---
+
+## `expected_skills` Field
+
+### Purpose
+
+Declares the skill corpus entries a generated project expects (FR-BNDL-2). Supports warn-not-error validation during `proj-cli` setup (FR-BNDL-3, implemented in Group 5 of the skill-template-separation plan).
+
+### Format
+
+```yaml
+expected_skills:
+  - commit
+  - decision
+  - explore
+  # ... bare identifiers, one per list item
+```
+
+**Rules:**
+
+1. **Bare identifiers only** — use the skill directory name (e.g. `explore`), not a service prefix (`ai-workflow/explore`).
+2. **Sorted alphabetically** in template sources (recommended for diff stability).
+3. **Strings only** — no nested objects or version pins in v1.
+4. **Non-blocking** — missing skills must never fail project setup (NFR-BNDL-1).
+
+### Identifier convention decision
+
+| Option | Example | Verdict |
+|--------|---------|---------|
+| Bare names | `explore` | ✅ **Chosen** — matches global install paths (`~/.cursor/skills/explore/`, `~/.claude/skills/explore/`) |
+| Namespaced | `ai-workflow/explore` | ❌ Rejected — no stable namespace in the external corpus product yet; adds lookup complexity without benefit for v1 |
+
+Group 5 (`proj-cli` validation) resolves each entry by checking for an installed skill directory under the user's global skills path.
+
+### Validation behavior (proj-cli)
+
+When `proj-cli` setup runs (Group 5):
+
+1. Read `expected_skills` from `.dev-infra.yml`.
+2. For each identifier, check whether the skill is installed globally.
+3. **Warn** for each missing skill with install guidance.
+4. **Never error** or block setup — projects must work without skills installed (graceful degradation via AGENTS.md and docs).
+
+---
+
+## Example
+
+**Standard project template** (`templates/standard-project/.dev-infra.yml`):
+
+```yaml
+template: standard-project
+version: "[DEV_INFRA_VERSION]"
+created: "[CREATED_DATE]"
+
+expected_skills:
+  - commit
+  - decision
+  - discuss
+  - explore
+  - handoff
+  - int-opp
+  - narrative
+  - plan-review
+  - pre-commit-review
+  - reflect
+  - research
+  - spike
+  - write-plan
+```
+
+Placeholders `[DEV_INFRA_VERSION]` and `[CREATED_DATE]` are substituted when project generation tooling fills metadata (future `new-project.sh` / `proj-cli` enhancement).
+
+---
+
+## Template inventory (2026-06-05)
+
+Both `standard-project` and `learning-project` templates ship the same 13-entry list — the skills formerly bundled under `templates/standard-project/.claude/skills/` before ADR-001 template cleanup (PR #107). The learning template never had a bundled skills tree but uses the same workflow commands and assumes the same global skill corpus.
+
+---
+
+## See Also
+
+- [Template Files Guide](TEMPLATE-FILES.md) — `.dev-infra.yml` in template file inventory
+- [Template Metadata Requirements](../admin/services/template-generation/features/template-metadata/requirements.md) — FR-8 file naming
+- [Skill-Template Separation implementation plan](../admin/services/meta/features/skill-template-separation/planning/implementation-plan.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@
 - **[Template Usage Guide](TEMPLATE-USAGE.md)** - How to use templates effectively
 - **[Project Types Guide](PROJECT-TYPES.md)** - Regular vs Learning project comparison
 - **[Template Files Guide](TEMPLATE-FILES.md)** - Standard files reference
+- **[.dev-infra.yml Reference](DEV-INFRA-YML.md)** - Project metadata schema and `expected_skills` manifest
 
 ### Advanced Usage
 - **[Best Practices Guide](BEST-PRACTICES.md)** - Comprehensive best practices

--- a/docs/TEMPLATE-FILES.md
+++ b/docs/TEMPLATE-FILES.md
@@ -2,7 +2,7 @@
 
 **Purpose:** Documentation of standard files included in project templates  
 **Status:** ✅ Complete  
-**Last Updated:** 2025-01-27
+**Last Updated:** 2026-06-05
 
 ---
 
@@ -15,6 +15,24 @@ This document describes the standard files included in each project template and
 ## 📁 Standard Project Template Files
 
 ### Configuration Files
+
+#### `.dev-infra.yml`
+
+**Purpose:** Dev-infra project metadata and skill expectation manifest (ADR-001)
+
+**Includes:**
+
+- `template` — which dev-infra template generated the project
+- `version` — dev-infra version at generation time
+- `created` — generation date (when populated)
+- `expected_skills` — bare skill identifiers the template workflow assumes (installed globally, not bundled)
+
+**Customization:**
+
+- Adjust `expected_skills` if your team uses a subset of the workflow skill corpus
+- Do not treat the list as a bundle — skills install from the external corpus product
+
+**Reference:** [.dev-infra.yml schema](DEV-INFRA-YML.md)
 
 #### `.gitignore`
 
@@ -103,6 +121,12 @@ This document describes the standard files included in each project template and
 ## 📚 Learning Project Template Files
 
 ### Configuration Files
+
+#### `.dev-infra.yml`
+
+**Purpose:** Same as standard-project — dev-infra metadata and `expected_skills` manifest (identical skill list; `template: learning-project`)
+
+**Reference:** [.dev-infra.yml schema](DEV-INFRA-YML.md)
 
 #### `.gitignore`
 

--- a/templates/learning-project/.dev-infra.yml
+++ b/templates/learning-project/.dev-infra.yml
@@ -1,4 +1,4 @@
-# Dev-infra project metadata — see docs/DEV-INFRA-YML.md in the dev-infra repo
+# Dev-infra project metadata — canonical inventory: docs/DEV-INFRA-YML.md (keep lists in sync)
 # Placeholders are filled at project generation time.
 
 template: learning-project

--- a/templates/learning-project/.dev-infra.yml
+++ b/templates/learning-project/.dev-infra.yml
@@ -1,0 +1,22 @@
+# Dev-infra project metadata — see docs/DEV-INFRA-YML.md in the dev-infra repo
+# Placeholders are filled at project generation time.
+
+template: learning-project
+version: "[DEV_INFRA_VERSION]"
+created: "[CREATED_DATE]"
+
+# Bare skill directory names (global install). proj-cli warns if missing; never blocks setup.
+expected_skills:
+  - commit
+  - decision
+  - discuss
+  - explore
+  - handoff
+  - int-opp
+  - narrative
+  - plan-review
+  - pre-commit-review
+  - reflect
+  - research
+  - spike
+  - write-plan

--- a/templates/learning-project/README.md
+++ b/templates/learning-project/README.md
@@ -23,7 +23,7 @@ This project includes a **`.dev-infra.yml`** file at the repository root. It rec
 
 - **Not a bundle:** Templates no longer ship skill or command copies; the manifest declares expectations only.
 - **Validation:** `proj-cli` setup will **warn** (not error) when listed skills are missing and point you to the external skill corpus.
-- **Reference:** See the dev-infra [.dev-infra.yml schema](https://github.com/grimm00/dev-infra/blob/develop/docs/DEV-INFRA-YML.md) for field definitions and identifier conventions.
+- **Reference:** Schema and canonical skill inventory live in the dev-infra repo [`docs/DEV-INFRA-YML.md`](https://github.com/grimm00/dev-infra/blob/develop/docs/DEV-INFRA-YML.md) (generated projects link out; dev-infra maintainers edit the doc + template copies together).
 
 Projects work without skills installed — documentation and hub READMEs orient you when skills are absent.
 

--- a/templates/learning-project/README.md
+++ b/templates/learning-project/README.md
@@ -17,6 +17,18 @@ By the end of this project, you will understand:
 
 ---
 
+## 📄 Project Metadata (`.dev-infra.yml`)
+
+This project includes a **`.dev-infra.yml`** file at the repository root. It records the dev-infra template type, generation version, and an **`expected_skills`** manifest — the workflow skills this template assumes you have installed globally.
+
+- **Not a bundle:** Templates no longer ship skill or command copies; the manifest declares expectations only.
+- **Validation:** `proj-cli` setup will **warn** (not error) when listed skills are missing and point you to the external skill corpus.
+- **Reference:** See the dev-infra [.dev-infra.yml schema](https://github.com/grimm00/dev-infra/blob/develop/docs/DEV-INFRA-YML.md) for field definitions and identifier conventions.
+
+Projects work without skills installed — documentation and hub READMEs orient you when skills are absent.
+
+---
+
 ## 🔍 Exploration/Research/Decision Workflows
 
 This project supports structured workflows for exploring ideas, conducting research, and making architectural decisions before transitioning to feature planning.

--- a/templates/standard-project/.dev-infra.yml
+++ b/templates/standard-project/.dev-infra.yml
@@ -1,4 +1,4 @@
-# Dev-infra project metadata — see docs/DEV-INFRA-YML.md in the dev-infra repo
+# Dev-infra project metadata — canonical inventory: docs/DEV-INFRA-YML.md (keep lists in sync)
 # Placeholders are filled at project generation time.
 
 template: standard-project

--- a/templates/standard-project/.dev-infra.yml
+++ b/templates/standard-project/.dev-infra.yml
@@ -1,0 +1,22 @@
+# Dev-infra project metadata — see docs/DEV-INFRA-YML.md in the dev-infra repo
+# Placeholders are filled at project generation time.
+
+template: standard-project
+version: "[DEV_INFRA_VERSION]"
+created: "[CREATED_DATE]"
+
+# Bare skill directory names (global install). proj-cli warns if missing; never blocks setup.
+expected_skills:
+  - commit
+  - decision
+  - discuss
+  - explore
+  - handoff
+  - int-opp
+  - narrative
+  - plan-review
+  - pre-commit-review
+  - reflect
+  - research
+  - spike
+  - write-plan

--- a/templates/standard-project/README.md
+++ b/templates/standard-project/README.md
@@ -80,7 +80,7 @@ This project includes a **`.dev-infra.yml`** file at the repository root. It rec
 
 - **Not a bundle:** Templates no longer ship skill or command copies; the manifest declares expectations only.
 - **Validation:** `proj-cli` setup will **warn** (not error) when listed skills are missing and point you to the external skill corpus.
-- **Reference:** See the dev-infra [.dev-infra.yml schema](https://github.com/grimm00/dev-infra/blob/develop/docs/DEV-INFRA-YML.md) for field definitions and identifier conventions.
+- **Reference:** Schema and canonical skill inventory live in the dev-infra repo [`docs/DEV-INFRA-YML.md`](https://github.com/grimm00/dev-infra/blob/develop/docs/DEV-INFRA-YML.md) (generated projects link out; dev-infra maintainers edit the doc + template copies together).
 
 Projects work without skills installed — AGENTS.md and documentation orient agents when skills are absent.
 

--- a/templates/standard-project/README.md
+++ b/templates/standard-project/README.md
@@ -74,9 +74,21 @@ This project follows a **hub-and-spoke documentation pattern**:
 
 ---
 
+## 📄 Project Metadata (`.dev-infra.yml`)
+
+This project includes a **`.dev-infra.yml`** file at the repository root. It records the dev-infra template type, generation version, and an **`expected_skills`** manifest — the workflow skills this template assumes you have installed globally.
+
+- **Not a bundle:** Templates no longer ship skill or command copies; the manifest declares expectations only.
+- **Validation:** `proj-cli` setup will **warn** (not error) when listed skills are missing and point you to the external skill corpus.
+- **Reference:** See the dev-infra [.dev-infra.yml schema](https://github.com/grimm00/dev-infra/blob/develop/docs/DEV-INFRA-YML.md) for field definitions and identifier conventions.
+
+Projects work without skills installed — AGENTS.md and documentation orient agents when skills are absent.
+
+---
+
 ## 🤖 Workflow Automation Commands
 
-This project includes workflow automation commands to streamline development, planning, and project management. All commands are located in `.cursor/commands/` and can be used directly in Cursor IDE.
+This project includes workflow automation commands to streamline development, planning, and project management. Commands and skills are installed globally (not bundled in the template) and can be used directly in Cursor IDE.
 
 ### Quick Reference
 


### PR DESCRIPTION
## Summary

- Introduces the **`expected_skills`** manifest field in `.dev-infra.yml` per ADR-001 FR-BNDL-2.
- Adds authoritative schema reference at `docs/DEV-INFRA-YML.md` (bare skill identifiers, warn-not-error validation semantics).
- Ships `templates/standard-project/.dev-infra.yml` and `templates/learning-project/.dev-infra.yml` with 13 skill entries matching the pre–PR #107 bundled corpus.
- Documents the field in both template READMEs and `docs/TEMPLATE-FILES.md`.
- Completes Group 4 planning artifacts (expanded task file, plan-review, status updates — 18/25 tasks).

## Why

Templates no longer bundle skills or commands (Groups 2–3). Projects still need a declarative record of which global workflow skills the template assumes. This group establishes the manifest contract that Group 5 (`proj-cli` validation) will consume.

**Identifier decision:** bare directory names (e.g. `explore`) — matches `~/.cursor/skills/<name>/` install layout; namespaced IDs deferred until the external corpus product stabilizes.

## After Merge

- **New files in generated projects:** `./scripts/new-project.sh` copies template trees — generated projects will include `.dev-infra.yml` with placeholder `version`/`created` values until generator substitution lands.
- **Group 5 dependency unblocked:** proj-cli can implement warn-not-error checks against `expected_skills`.
- **Template README caveat:** Workflow sections still mention legacy `.cursor/commands/` paths in places — broader prose refresh remains Group 6 scope; this PR adds the `.dev-infra.yml` section only.
- **No CI workflow changes** in this PR.

## Follow-ups

- **Group 5:** Implement proj-cli `expected_skills` validation (warn + install guidance).
- **Group 6:** Update dev-infra AGENTS.md, supersede `global-command-distribution`, refresh stale command-location prose in template READMEs.
- **Future:** `new-project.sh` placeholder substitution for `[DEV_INFRA_VERSION]` and `[CREATED_DATE]`.
