### PR TITLE
feat(skill-template-separation): Documentation & Supersession (Group 6)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ dev-infra/
 │       └── meta/                  # Dev-infra about itself
 ```
 
-AI workflow tools (skills, commands, agents) are installed globally at `~/.cursor/` — not tracked in this repo. Authoritative template copies live in `templates/standard-project/`.
+AI workflow tools (skills, commands, agents) are installed globally at `~/.cursor/` and `~/.claude/` — not tracked in this repo. The skill corpus is a **separate product** per [ADR-001](admin/services/meta/features/skill-template-separation/decisions/adr-001-separation-model.md); dev-infra templates carry **no bundled copies**, only an `expected_skills` manifest in `.dev-infra.yml` (see [docs/DEV-INFRA-YML.md](docs/DEV-INFRA-YML.md)).
 
 Each service contains: `explorations/` (pre-formal thinking), `features/` (formal work with planning pipeline), and `maintenance/` (operational upkeep). Features follow the structure: `[feature]/planning/implementation-plan.md` + `tasks/` + `status-and-next-steps.md`.
 
@@ -58,15 +58,16 @@ Each service contains: `explorations/` (pre-formal thinking), `features/` (forma
 
 ## Template Standards
 
-**Two template types:** standard-project (application scaffold with backend/frontend separation, feature-based planning) and learning-project (stage-based progression with practice apps and reference materials). Both receive all workflow commands/skills.
+**Two template types:** standard-project (application scaffold with backend/frontend separation, feature-based planning) and learning-project (stage-based progression with practice apps and reference materials). Both declare workflow skill expectations via `expected_skills` in `.dev-infra.yml` — not bundled skill/command copies.
 
 **When modifying templates:**
 1. Test generation with `./scripts/new-project.sh`
 2. Verify generated structure, README files, and documentation links
 3. Update user docs in `docs/` and planning docs if feature-related
 4. Maintain consistency across template types and preserve proven patterns
+5. Keep `expected_skills` in sync with [docs/DEV-INFRA-YML.md](docs/DEV-INFRA-YML.md) when the assumed corpus changes
 
-**Template sync:** Shared files between templates are tracked in `scripts/template-sync-manifest.txt` and validated in CI via `scripts/validate-template-sync.sh`.
+**Skill expectations:** Templates ship `.dev-infra.yml` with an `expected_skills` list. `proj-cli` validates installed skills with warn-not-error semantics during project setup. Generated projects work without skills installed (graceful degradation via AGENTS.md and docs).
 
 **Placeholder patterns:** `[PROJECT_NAME]`, `[PROJECT_DESCRIPTION]`, `[TECH_STACK]`, `[AUTHOR]` — replaced during generation.
 

--- a/admin/feedback/sourcery/pr111.md
+++ b/admin/feedback/sourcery/pr111.md
@@ -1,0 +1,34 @@
+# Sourcery Review Analysis
+**PR**: #111
+**Repository**: grimm00/dev-infra
+**Generated**: 2026-06-09 (group-cycle Step 4 validation)
+
+---
+
+## Summary
+
+Total Individual Comments: 0 + 1 Overall Comment (approval, no actionable findings)
+
+Sourcery posted a Reviewer's Guide summarizing file-level changes. Overall assessment: "I've reviewed your changes and they look great!" — no inline suggestions or fix requests.
+
+## Individual Comments
+
+*(none)*
+
+## Overall Comments
+
+- **Approval:** "Hey - I've reviewed your changes and they look great!" — no code or documentation changes requested.
+
+## Priority Matrix Assessment
+
+| Comment | Priority | Impact | Effort | Action |
+|---------|----------|--------|--------|--------|
+| Reviewer's Guide (informational summary only) | — | — | — | No action — Sourcery approval with no findings |
+
+### Verdict
+
+No CRITICAL, HIGH, MEDIUM, or LOW fix items. Reviewer's Guide is informational only.
+
+---
+
+**Status:** ✅ NONE — All issues addressed or no issues found

--- a/admin/services/meta/features/four-arm-architecture/README.md
+++ b/admin/services/meta/features/four-arm-architecture/README.md
@@ -11,6 +11,10 @@
 - **[research/](research/)** — requirements (promoted to root), summary, 7 topics
 - **[decisions/](decisions/)** — 3 ADRs + decisions summary
 
+## Distribution & Corpus Ownership
+
+The four-arm ADRs assumed dev-infra owned command content in templates. [Skill-template-separation ADR-001](../skill-template-separation/decisions/adr-001-separation-model.md) (2026) extends this architecture: the skill corpus is a **separate product**, templates carry only an `expected_skills` manifest, and `proj-cli` validates with warn-not-error semantics. Supersedes the [global-command-distribution](../global-command-distribution/) feature plan.
+
 ## Provenance
 
 Promoted from service-level exploration: [../../explorations/four-arm-architecture/](../../explorations/four-arm-architecture/)

--- a/admin/services/meta/features/global-command-distribution/README.md
+++ b/admin/services/meta/features/global-command-distribution/README.md
@@ -1,8 +1,10 @@
 # global-command-distribution
 
 **Purpose:** Distribute workflow commands globally across all projects
-**Status:** 🟡 Planned
+**Status:** 🔴 Superseded
 **Created:** 2026-04-24
+
+> **Superseded by [skill-template-separation ADR-001](../skill-template-separation/decisions/adr-001-separation-model.md) (2026).** The skill corpus is now a separate product; templates carry an `expected_skills` manifest instead of bundled command copies. Research below is preserved for provenance.
 
 ---
 

--- a/admin/services/meta/features/skill-template-separation/README.md
+++ b/admin/services/meta/features/skill-template-separation/README.md
@@ -1,0 +1,36 @@
+# skill-template-separation
+
+**Purpose:** Formalize skill corpus as a separate product from dev-infra templates (ADR-001)
+**Status:** ✅ Complete
+**Created:** 2026-05-22
+**Completed:** 2026-06-09
+
+---
+
+## Quick Links
+
+- **[ADR-001: Separation Model](decisions/adr-001-separation-model.md)** — accepted decision
+- **[Implementation Plan](planning/implementation-plan.md)** — 25 tasks across 6 groups
+- **[Status & Next Steps](planning/status-and-next-steps.md)** — progress tracking
+- **[.dev-infra.yml schema](../../../../../docs/DEV-INFRA-YML.md)** — `expected_skills` manifest reference
+
+---
+
+## Overview
+
+Implements ADR-001: removes bundled skills/commands/agents from templates, retires `template-sync-manifest.txt`, introduces `expected_skills` in `.dev-infra.yml`, and adds proj-cli warn-not-error validation. Sibling ADRs (installation architecture, per-repo profile schema) are out of scope — separate plans.
+
+**Supersedes:** [global-command-distribution](../global-command-distribution/) (December 2025)
+
+**Extends:** [four-arm-architecture](../four-arm-architecture/) — resolves what ships in templates vs. the external corpus.
+
+---
+
+## Phase Directories
+
+- **[decisions/](decisions/)** — ADR-001 (accepted); ADR-002/003 on research branch
+- **[planning/](planning/)** — implementation plan, task groups, plan reviews
+
+## Provenance
+
+Exploration: [../../explorations/skill-template-separation/](../../explorations/skill-template-separation/)

--- a/admin/services/meta/features/skill-template-separation/decisions/adr-001-separation-model.md
+++ b/admin/services/meta/features/skill-template-separation/decisions/adr-001-separation-model.md
@@ -2,7 +2,7 @@
 
 **Status:** ✅ Accepted
 **Accepted:** 2026-06-09
-**Implementation:** PRs #106–#110 (Groups 1–5); Group 6 documentation PR pending
+**Implementation:** PRs #106–#111 (Groups 1–6)
 **Decision topic:** `skill-template-separation`
 
 ---

--- a/admin/services/meta/features/skill-template-separation/decisions/adr-001-separation-model.md
+++ b/admin/services/meta/features/skill-template-separation/decisions/adr-001-separation-model.md
@@ -1,6 +1,8 @@
 # ADR-001: Skill-Template Separation Model
 
-**Status:** 🔴 Proposed
+**Status:** ✅ Accepted
+**Accepted:** 2026-06-09
+**Implementation:** PRs #106–#110 (Groups 1–5); Group 6 documentation PR pending
 **Decision topic:** `skill-template-separation`
 
 ---

--- a/admin/services/meta/features/skill-template-separation/planning/implementation-plan.md
+++ b/admin/services/meta/features/skill-template-separation/planning/implementation-plan.md
@@ -29,7 +29,7 @@ tasks_files:
 ---
 # Implementation Plan — Skill-Template Separation (ADR-001)
 
-**Status:** 🟠 In Progress
+**Status:** ✅ Complete
 **Created:** 2026-05-22
 **Last Updated:** 2026-06-09
 **Source:** [decisions/adr-001-separation-model.md](../decisions/adr-001-separation-model.md)
@@ -98,20 +98,20 @@ This plan covers ADR-001 only. ADR-002 (installation architecture / symlinks) an
 - [x] Task 22: Test graceful degradation (generated project works without skills installed) — PR #110 (2026-06-09)
 
 ### Documentation & Supersession
-- [ ] Task 23: Mark `global-command-distribution` feature README as superseded by ADR-001
-- [ ] Task 24: Update dev-infra AGENTS.md / docs to reflect template minimalism + manifest pattern
-- [ ] Task 25: Cross-link ADR-001 from four-arm-architecture and skill-template-separation hubs
+- [x] Task 23: Mark `global-command-distribution` feature README as superseded by ADR-001
+- [x] Task 24: Update dev-infra AGENTS.md / docs to reflect template minimalism + manifest pattern
+- [x] Task 25: Cross-link ADR-001 from four-arm-architecture and skill-template-separation hubs
 
 ---
 
 ## ✅ Definition of Done
 
-- [ ] All 25 tasks complete (22/25 done; Groups 1–5 ✅)
+- [x] All 25 tasks complete (25/25; Groups 1–6 ✅)
 - [x] CI passes on the new feature branch (demonstrated on PRs #106, #107, #108)
 - [x] Generated project (via `./scripts/new-project.sh`) contains no bundled skills/commands/agents — manifest in `.dev-infra.yml` (PR #109); Group 5 adds proj-cli warn-not-error validation
 - [x] `proj-cli` setup warns (not errors) when expected skills are missing — proj-cli `src/proj/skills.py` (Group 5)
 - [x] `template-sync-manifest.txt` and validator removed; CI green without them (PR #108, 2026-06-04)
-- [ ] ADR-001 status moved from 🔴 Proposed → ✅ Accepted (acceptance recorded in the ADR file) — pending Group 6
+- [x] ADR-001 status moved from 🔴 Proposed → ✅ Accepted (acceptance recorded in the ADR file)
 - [x] PR to `develop` carries only ADR-001 + planning tree (no research, no exploration, no other ADRs) — done by PR #106 (Group 1)
 
 ---

--- a/admin/services/meta/features/skill-template-separation/planning/implementation-plan.md
+++ b/admin/services/meta/features/skill-template-separation/planning/implementation-plan.md
@@ -95,7 +95,7 @@ This plan covers ADR-001 only. ADR-002 (installation architecture / symlinks) an
 - [x] Task 19: Design `proj-cli` `expected_skills` validation step (warn-not-error)
 - [x] Task 20: Implement validation logic in `proj-cli` setup flow
 - [x] Task 21: Add install-guidance message text pointing to the corpus
-- [x] Task 22: Test graceful degradation (generated project works without skills installed)
+- [x] Task 22: Test graceful degradation (generated project works without skills installed) — PR #110 (2026-06-09)
 
 ### Documentation & Supersession
 - [ ] Task 23: Mark `global-command-distribution` feature README as superseded by ADR-001

--- a/admin/services/meta/features/skill-template-separation/planning/plan-review-2026-06-09-group6.md
+++ b/admin/services/meta/features/skill-template-separation/planning/plan-review-2026-06-09-group6.md
@@ -1,0 +1,81 @@
+# Plan Review — Skill-Template Separation (Group 6)
+
+**Feature:** skill-template-separation  
+**Planning root:** `admin/services/meta/features/skill-template-separation/planning/`  
+**Status:** ✅ Ready  
+**Reviewed:** 2026-06-09  
+**Scope:** Group 6 only (Tasks 23–25) — final group  
+
+---
+
+## 📋 Plan Structure
+
+- [x] Implementation plan found and parseable
+- [x] YAML frontmatter valid (`task_count: 25`, `groups`, `tasks_files`)
+- [x] Group 6 task file exists (`tasks/06-documentation-and-supersession.md`)
+- [x] Checkbox census: 22/25 complete post-PR #110
+- [x] No orphan global task IDs
+
+---
+
+## 📝 Task Group Review
+
+### Group 6: Documentation & Supersession (Tasks 23–25)
+
+- **Header status:** 🔴 Scaffolding — needs expansion (expected before Step 1)
+- **Task count:** 3 (within 2–8 range)
+- **Descriptions:** Supersede global-command-distribution → update AGENTS.md → cross-link ADR-001
+- **Dependencies section:** Group 5 prerequisite satisfied (PR #110 merged)
+
+---
+
+## 🔗 Dependency Validation
+
+- [x] Groups 1–5 complete before Group 6 execution
+- [x] ADR-001 implementation real (manifest, proj-cli validation, template cleanup) — not just declared
+- [x] No circular dependencies
+- [x] Final group closes Definition of Done (ADR acceptance + feature complete)
+
+---
+
+## 🔄 Consistency Check
+
+- [x] Plan ↔ Status progress counts align (22/25 after Group 5 closeout)
+- [x] Tasks 19–22 checked in implementation-plan
+- [x] Stale AGENTS.md line identified ("Authoritative template copies live in `templates/standard-project/`")
+- [x] Stale template-sync prose in AGENTS.md (manifest retired PR #108)
+- [x] PR #109 deferred item `PR109-Overall-#2` flagged for Group 6 sweep
+
+---
+
+## 🔴 Blockers
+
+*(none)*
+
+---
+
+## 🟡 Warnings
+
+- **No feature hub README on develop** — only exploration hub exists; Task 25 may need a curated feature hub under `admin/services/meta/features/skill-template-separation/README.md`.
+- **ADR acceptance is Group 6 deliverable** — `adr-001-separation-model.md` still 🔴 Proposed; flip to ✅ Accepted when tasks complete.
+
+---
+
+## 💡 Recommendations
+
+- Supersession note on `global-command-distribution/README.md` — one line, preserve provenance (do not delete).
+- AGENTS.md: replace bundled-corpus language with external corpus + `expected_skills` manifest pattern; remove template-sync-manifest references.
+- four-arm-architecture hub: link ADR-001 (skill-template-separation) as the extension resolving "what ships where."
+
+---
+
+## ✅ Readiness Assessment
+
+**Verdict:** ✅ Ready for Group 6 expansion and execution.
+
+All implementation groups merged. Documentation sweep is the remaining work; docs-only — markdown/link validation sufficient.
+
+---
+
+**Reviewed by:** group-cycle agent  
+**Next:** Expand `tasks/06-documentation-and-supersession.md`, then execute Tasks 23–25

--- a/admin/services/meta/features/skill-template-separation/planning/status-and-next-steps.md
+++ b/admin/services/meta/features/skill-template-separation/planning/status-and-next-steps.md
@@ -15,15 +15,14 @@
 | Template Cleanup | ✅ Complete | 5/5 tasks | Merged PR #107 (2026-06-03); 82 bundled files removed |
 | Template-Sync-Manifest Retirement | ✅ Complete | 4/4 tasks | Merged PR #108 (2026-06-04); `develop` Run Tests confirmed green post-merge |
 | expected_skills Manifest in Templates | ✅ Complete | 4/4 tasks | Merged PR #109 (2026-06-09); `.dev-infra.yml` + `docs/DEV-INFRA-YML.md` |
-| proj-cli Validation | ✅ Complete | 4/4 tasks | proj-cli `skills.py` + dev-infra graceful-degradation Bats |
+| proj-cli Validation | ✅ Complete | 4/4 tasks | Merged PR #110 (2026-06-09); proj-cli `skills.py` + dev-infra graceful-degradation Bats |
 | Documentation & Supersession | 🔴 Not Started | 0/3 tasks | global-command-distribution superseded; AGENTS.md updated |
 
 ---
 
 ## 🚀 Next Steps
 
-1. **Group 6:** Documentation & supersession (mark `global-command-distribution` superseded, update AGENTS.md, cross-link from four-arm-architecture).
-2. **Companion:** Merge proj-cli branch `feat/skill-template-separation-expected-skills-validation` (Tasks 20–21 code).
+1. **Group 6:** Documentation & supersession (mark `global-command-distribution` superseded, update AGENTS.md, cross-link from four-arm-architecture, accept ADR-001).
 
 ---
 
@@ -43,6 +42,7 @@
 - **Group 3 merge:** PR #108 retired `template-sync-manifest.txt`, `validate-template-sync.sh`, dedicated Bats suite, and the CI workflow step that invoked them (2026-06-04). `develop` Run Tests confirmed green post-merge — Group 2's admin override is now resolved.
 - **Group 4 identifier convention (Task 15):** Bare skill directory names (not namespaced) for `expected_skills` v1.
 - **Group 4 merge:** PR #109 landed `expected_skills` manifest in both templates, `docs/DEV-INFRA-YML.md`, and template README / `TEMPLATE-FILES` cross-links (2026-06-09).
+- **Group 5 merge:** PR #110 landed proj-cli `expected_skills` validation design, graceful-degradation Bats, and `docs/DEV-INFRA-YML.md` behavioral phrasing fix (2026-06-09). Sourcery `PR110-Overall-#1` (Bats string coupling) deferred; `PR110-Overall-#2` fixed inline.
 
 ## 📋 Deferred
 

--- a/admin/services/meta/features/skill-template-separation/planning/status-and-next-steps.md
+++ b/admin/services/meta/features/skill-template-separation/planning/status-and-next-steps.md
@@ -1,13 +1,13 @@
 # Status & Next Steps — Skill-Template Separation (ADR-001)
 
-**Status:** 🟠 In Progress
+**Status:** ✅ Complete
 **Last Updated:** 2026-06-09
 
 ---
 
 ## 📊 Progress Summary
 
-**Overall:** 22/25 tasks complete
+**Overall:** 25/25 tasks complete
 
 | Group | Status | Progress | Notes |
 |-------|--------|----------|-------|
@@ -16,13 +16,17 @@
 | Template-Sync-Manifest Retirement | ✅ Complete | 4/4 tasks | Merged PR #108 (2026-06-04); `develop` Run Tests confirmed green post-merge |
 | expected_skills Manifest in Templates | ✅ Complete | 4/4 tasks | Merged PR #109 (2026-06-09); `.dev-infra.yml` + `docs/DEV-INFRA-YML.md` |
 | proj-cli Validation | ✅ Complete | 4/4 tasks | Merged PR #110 (2026-06-09); proj-cli `skills.py` + dev-infra graceful-degradation Bats |
-| Documentation & Supersession | 🔴 Not Started | 0/3 tasks | global-command-distribution superseded; AGENTS.md updated |
+| Documentation & Supersession | ✅ Complete | 3/3 tasks | Group 6 PR — supersession, AGENTS.md, ADR-001 accepted |
 
 ---
 
 ## 🚀 Next Steps
 
-1. **Group 6:** Documentation & supersession (mark `global-command-distribution` superseded, update AGENTS.md, cross-link from four-arm-architecture, accept ADR-001).
+Feature complete. Follow-on work is out of scope for this plan:
+
+- **ADR-002** (installation architecture) — separate implementation plan
+- **ADR-003** (per-repo profile schema) — separate implementation plan
+- **Deferred:** `PR110-Overall-#1` Bats test-robustness pass; `PR109-Overall-#2` template README URL pattern (documented as intentional)
 
 ---
 
@@ -31,7 +35,7 @@
 - Plan generated from `decisions/adr-001-separation-model.md` on 2026-05-22.
 - **Doc surface intent:** ADR-001 + planning tree on `develop`; research on `docs/skill-template-separation-research`.
 - ADR-002 and ADR-003 out of scope for this plan.
-- **CI:** Green on `develop` as of PR #109 merge (2026-06-09).
+- **CI:** Green on `develop` as of PR #110 merge (2026-06-09).
 - **Group 4:** Bare skill identifiers chosen for `expected_skills` (matches `~/.cursor/skills/<name>/` layout); 13 entries mirror pre-#107 bundled corpus.
 
 ## 🧭 Decisions Made
@@ -43,6 +47,7 @@
 - **Group 4 identifier convention (Task 15):** Bare skill directory names (not namespaced) for `expected_skills` v1.
 - **Group 4 merge:** PR #109 landed `expected_skills` manifest in both templates, `docs/DEV-INFRA-YML.md`, and template README / `TEMPLATE-FILES` cross-links (2026-06-09).
 - **Group 5 merge:** PR #110 landed proj-cli `expected_skills` validation design, graceful-degradation Bats, and `docs/DEV-INFRA-YML.md` behavioral phrasing fix (2026-06-09). Sourcery `PR110-Overall-#1` (Bats string coupling) deferred; `PR110-Overall-#2` fixed inline.
+- **Group 6:** ADR-001 accepted (2026-06-09); `global-command-distribution` superseded; AGENTS.md reflects template minimalism; feature hub created on develop.
 
 ## 📋 Deferred
 
@@ -54,8 +59,11 @@
 - Task-doc `**Last Updated:**` deduplication — project-wide convention pattern across all 6 task docs (top metadata + trailing line). Tracked as `PR108-Overall-#2` in `admin/feedback/deferred-tasks.md` for a future convention-sweep PR.
 
 **From PR #109:**
-- **PR109-Overall-#2:** Template README absolute GitHub URL for `.dev-infra.yml` schema — deferred to Group 6 documentation sweep (generated projects lack in-repo `docs/` tree). Tracked in `admin/feedback/deferred-tasks.md`.
+- **PR109-Overall-#2:** Template README absolute GitHub URL for `.dev-infra.yml` schema — intentional for generated projects (no in-repo `docs/` tree); documented in Group 6 status.
 - **PR109-Overall-#1:** Fixed inline (YAML headers reference canonical `docs/DEV-INFRA-YML.md` inventory).
+
+**From PR #110:**
+- **PR110-Overall-#1:** Graceful-degradation Bats string coupling — deferred for deliberate test-robustness pass.
 
 ---
 

--- a/admin/services/meta/features/skill-template-separation/planning/tasks/06-documentation-and-supersession.md
+++ b/admin/services/meta/features/skill-template-separation/planning/tasks/06-documentation-and-supersession.md
@@ -2,26 +2,22 @@
 
 **Feature:** Skill-Template Separation (ADR-001)
 **Group:** Documentation & Supersession
-**Status:** 🔴 Scaffolding (needs expansion)
-**Last Updated:** 2026-05-22
+**Status:** ✅ Complete
+**Last Updated:** 2026-06-09
 
-> ⚠️ Scaffolding only — run `write-plan-expand` on this file to flesh out steps and acceptance criteria.
+---
+
+## 📌 Operating Context
+
+Final group — closes ADR-001 acceptance and the 25-task implementation plan. All code paths (template cleanup, manifest, proj-cli validation) are merged (PRs #106–#110). This group is documentation-only: supersede the December 2025 `global-command-distribution` feature, refresh stale AGENTS.md prose, cross-link ADR-001 from architecture hubs, and accept ADR-001.
 
 ---
 
 ## 📝 Tasks
 
-- [ ] Task 23: Mark `global-command-distribution` feature README as superseded by ADR-001
-  - Per Topic 6 audit recommendation, add a one-line "Superseded by skill-template-separation ADR-001 (2026)" note.
-  - Do NOT delete the old feature docs — they preserve provenance.
-
-- [ ] Task 24: Update dev-infra AGENTS.md / docs to reflect template minimalism + manifest pattern
-  - Note that templates no longer bundle skills; describe the `expected_skills` mechanism.
-  - Update the Template Standards section to reflect the new minimal approach.
-
-- [ ] Task 25: Cross-link ADR-001 from four-arm-architecture and skill-template-separation hubs
-  - Four-arm-architecture's ADRs implicitly assumed dev-infra owned the corpus — link ADR-001 as the extension that resolves the "what ships where" question.
-  - Update or create a hub README on develop that points to ADR-001 (matching the curated doc-surface goal).
+- [x] Task 23: Mark `global-command-distribution` feature README as superseded by ADR-001
+- [x] Task 24: Update dev-infra AGENTS.md / docs to reflect template minimalism + manifest pattern
+- [x] Task 25: Cross-link ADR-001 from four-arm-architecture and skill-template-separation hubs
 
 ---
 
@@ -30,21 +26,33 @@
 1. Old feature documentation reflects its supersession.
 2. Project conventions (AGENTS.md) reflect the new template philosophy.
 3. The four-arm-architecture's distribution story is closed by ADR-001's reference.
+4. ADR-001 formally accepted; feature marked complete.
 
 ---
 
 ## ✅ Completion Criteria
 
-- [ ] `global-command-distribution/README.md` annotated as superseded
-- [ ] dev-infra AGENTS.md updated; review confirms accuracy
-- [ ] Cross-references in place from four-arm-architecture and the feature hub
+- [x] `global-command-distribution/README.md` annotated as superseded
+- [x] dev-infra AGENTS.md updated; review confirms accuracy
+- [x] Cross-references in place from four-arm-architecture and the feature hub
+- [x] ADR-001 accepted; 25/25 tasks complete
+
+---
+
+## 📊 Progress Tracking
+
+| Task | Status | Notes |
+|------|--------|-------|
+| Task 23: Supersede global-command-distribution | ✅ Complete | Supersession callout + link |
+| Task 24: Update AGENTS.md | ✅ Complete | Manifest pattern; sync retired |
+| Task 25: Cross-link + ADR acceptance | ✅ Complete | Feature hub + four-arm link |
 
 ---
 
 ## 🔗 Dependencies
 
-- Group 5 (proj-cli Validation) — last group runs only after the implementation is real, not just declared.
+- Group 5 (proj-cli Validation) — merged PR #110.
 
 ---
 
-**Last Updated:** 2026-05-22
+**Last Updated:** 2026-06-09


### PR DESCRIPTION
## Summary

- Closes the skill-template-separation feature (25/25 tasks) — final documentation group after PRs #106–#110 landed the implementation.
- Marks `global-command-distribution` as superseded by ADR-001 with provenance preserved.
- Updates `AGENTS.md` to reflect template minimalism: external skill corpus, `expected_skills` manifest, retired template-sync-manifest.
- Creates skill-template-separation feature hub on develop and cross-links ADR-001 from four-arm-architecture.
- Accepts ADR-001 (🔴 Proposed → ✅ Accepted, 2026-06-09).
- Post-PR #110 closeout: Group 5 status, plan review for Group 6 readiness.

## Why

ADR-001 formalized the skill corpus as a separate product from dev-infra templates. Groups 1–5 removed bundled tooling, introduced the manifest, and added proj-cli validation. Group 6 closes the loop: project conventions and architecture hubs must reflect the new model, the superseded December 2025 distribution feature must be annotated, and ADR-001 must be formally accepted to complete the Definition of Done.

## After Merge

- `AGENTS.md` becomes the authoritative statement that templates carry `expected_skills` manifests, not bundled skills — all future template work should follow this model.
- `global-command-distribution` is marked superseded; new distribution work should reference skill-template-separation ADR-001.
- ADR-001 status is ✅ Accepted — downstream ADR-002/003 plans can reference it as settled.
- Feature status is ✅ Complete; follow-on work (ADR-002 installation, ADR-003 profiles) requires separate implementation plans.
- No code or CI workflow changes — docs-only PR.

## Follow-ups

- `PR110-Overall-#1`: Graceful-degradation Bats string coupling — deferred for deliberate test-robustness pass.
- `PR109-Overall-#2`: Template README external GitHub URL for schema — intentional for generated projects; documented in status.
- Update ADR-001 **Implementation** line with PR #111 number after merge.
