### PR TITLE
docs(skill-corpus-installation): remaining planning updates + workflow course-correction

### DIFF
--- a/admin/planning/opportunities/internal/dev-infra/improvements/feature-work-bypassed-pr-via-docs-allowance.md
+++ b/admin/planning/opportunities/internal/dev-infra/improvements/feature-work-bypassed-pr-via-docs-allowance.md
@@ -1,0 +1,82 @@
+# Feature-Scale Work Bypassed PR via the Docs-Direct Allowance
+
+**Source:** Realization mid-`skill-corpus-installation` (2026-06-09)
+**Target:** dev-infra Git Flow conventions + `/task` workflow
+**Status:** 🔴 Not Started
+**Priority:** MEDIUM (process integrity; caught after ~12 direct commits)
+**Effort:** LOW (a convention clarification + a `/task` nudge)
+**Confidence:** ✅ Clear — the divergence is concrete and observed.
+**Created:** 2026-06-09
+**Last Updated:** 2026-06-09
+
+---
+
+## Problem Statement
+
+AGENTS.md Git Flow allows `docs/*` and `chore/*` to "push directly to develop/main
+with minimal validation," while `feat/*` requires a PR. During
+`skill-corpus-installation`, the dev-infra side of the feature is **all planning
+docs** (`.md` under `admin/`), so every commit was a `docs(...)` commit — and ~12 of
+them landed **directly on `develop`** across Groups 1–3, with **no feat branch, no PR,
+no review checkpoint, and no CI gate on the feature as a unit**.
+
+This is *technically* within the letter of the docs-direct allowance, but it bypassed
+the **spirit** of the established workflow. The sibling feature
+`skill-template-separation` ran the intended way: `feat/*` branch per group → PR →
+review/CI → merge (PRs #106–#111). The difference: that feature touched code;
+this one's dev-infra footprint is docs-only, so the allowance silently applied
+commit-by-commit and nobody hit a branch/PR gate.
+
+Two compounding factors made it frictionless to not notice:
+1. **The interactive `/task` flow** committed each task's doc updates straight to
+   develop (the command's own docs-only detection sanctions direct merge).
+2. **The real code lives in external repos** (`agentic-ocean`), so dev-infra never
+   "felt" like it was hosting feature code — yet it was hosting the feature's entire
+   planning lifecycle.
+
+Related: the external corpus repos (`agentic-ocean`) also received commits straight to
+`main` until this was caught (now corrected: `develop` + feat/PR established there).
+
+---
+
+## Why It Matters
+
+- No PR = no review checkpoint and no CI gate on the feature as a coherent unit.
+- Divergence from the documented convention erodes the convention.
+- A reader can't review the feature as a whole (it's dribbled across develop history).
+
+---
+
+## Proposed Improvements
+
+1. **Clarify the docs-direct allowance.** State in AGENTS.md (and `/task`'s docs-only
+   detection) that direct-to-develop is for **one-off doc fixes**, *not* for running a
+   multi-group **feature's** planning tree. A feature is branch-and-PR even when its
+   footprint is docs-only.
+2. **`/task` nudge.** When `/task` operates inside a feature planning tree
+   (`features/<feature>/planning/`) and detects a multi-group plan, it should **nudge
+   onto a `docs/*` or `feat/*` branch + PR** rather than committing to develop — or at
+   least warn once per feature.
+3. **Branch-first for feature planning.** Consider: even docs-only feature work starts
+   on a branch (matches `skill-template-separation`), so the feature lands via one (or
+   per-group) reviewable PR.
+
+---
+
+## Cheap to Reverse
+
+These are convention + a soft nudge, not enforcement. If the nudge proves noisy, drop
+it; the AGENTS.md clarification is harmless either way.
+
+---
+
+## Related
+
+- AGENTS.md — Git Flow (branch rules, docs/chore direct-merge allowance)
+- `~/.cursor/commands/task.md` — docs-only detection / direct-merge workflow
+- `skill-corpus-installation` (this feature) — the case that surfaced it
+- `skill-template-separation` — the sibling feature that followed feat→PR correctly
+
+---
+
+**Last Updated:** 2026-06-09

--- a/admin/services/ai-workflow/features/skill-corpus-installation/planning/implementation-plan.md
+++ b/admin/services/ai-workflow/features/skill-corpus-installation/planning/implementation-plan.md
@@ -77,7 +77,7 @@ Implements ADR-002 — gives the skill corpus (separated into its own product by
 ### Installer Mapping & XDG Config
 - [x] Task 8: Define the `installer.yaml` **multi-source** mapping schema (two source repos → editor paths)
 - [x] Task 9: Establish `~/.config/agentic-ocean/` config home + example mapping (core + personal blocks)
-- [ ] Task 10: Document XDG config vs corpus-project separation (Theme 10)
+- [x] Task 10: Document XDG config vs corpus-project separation (Theme 10)
 
 ### Installer Script
 - [ ] Task 11: Implement `install.sh` (read multi-source mapping, create symlinks, idempotent)

--- a/admin/services/ai-workflow/features/skill-corpus-installation/planning/status-and-next-steps.md
+++ b/admin/services/ai-workflow/features/skill-corpus-installation/planning/status-and-next-steps.md
@@ -7,13 +7,13 @@
 
 ## 📊 Progress Summary
 
-**Overall:** 9/21 tasks complete
+**Overall:** 10/21 tasks complete
 
 | Group | Status | Progress | Notes |
 |-------|--------|----------|-------|
 | Symlink Loading Spike | ✅ Complete | 3/3 tasks | C-INST-1 **GO** (Cursor 3.7.19: discovery + live-edit verified). `~/.claude/` deferred to int-opp. See `spike-c-inst-1-findings.md`. |
 | Corpus Repository Structure | ✅ Complete | 4/4 tasks | Two repos live: [agentic-ocean](https://github.com/grimm00/agentic-ocean) (public) + [agentic-ocean-personal](https://github.com/grimm00/agentic-ocean-personal) (private). Classified, bootstrapped (nightly), trimmed, migrated-split, READMEs, pushed. |
-| Installer Mapping & XDG Config | 🟠 In Progress | 2/3 tasks | Tasks 8–9 ✅ (schema + live `~/.config/agentic-ocean/installer.yaml`, validated). Next: Task 10 config-vs-corpus doc |
+| Installer Mapping & XDG Config | ✅ Complete | 3/3 tasks | Schema + live `~/.config/agentic-ocean/installer.yaml` + config-vs-corpus doc (corpus PR #1). |
 | Installer Script | 🔴 Not Started | 0/5 tasks | `install.sh` — idempotent, reversible, Bats-tested; + core→personal lint |
 | Source Install & Multi-Machine (Tier 2) | 🔴 Not Started | 0/3 tasks | two-repo `clone → install` (private auth); retire proj-cli placeholder |
 | Documentation & ADR Acceptance | 🔴 Not Started | 0/3 tasks | Guide + cross-links; ADR-002 → Accepted |
@@ -25,7 +25,9 @@
 1. ✅ Group 1 (Symlink Loading Spike) complete (2026-06-09) — C-INST-1 resolved GO; symlink mode is the primary installer mechanism.
 2. ✅ Plan re-partitioned (2026-06-09, 19→21 tasks) per `plan-review-2026-06-09.md` + ADR-001 — Groups 2–5 now reflect two repos, proj-cli-nightly bootstrap, multi-source mapping, the core→personal lint, and private-repo clone.
 3. ✅ Group 2 (Corpus Repository Structure) **complete** (2026-06-09) — both repos exist, populated, and pushed (core public / personal private).
-4. ✅ Group 3 (Installer Mapping & XDG Config) **expanded** (2026-06-09) — Tasks 8–10 carry Purpose/Steps/Files/Acceptance (multi-source schema mapping `corpus/`, per-item links, collision=error; `~/.config/agentic-ocean/installer.yaml`; config-vs-corpus doc). **Execute next.** Artifacts land in the **core repo** + `~/.config/agentic-ocean/`, not dev-infra.
+4. ✅ Group 3 (Installer Mapping & XDG Config) **complete** (2026-06-09) — schema (`installer.example.yaml` + `docs/installer-schema.md`), live `~/.config/agentic-ocean/installer.yaml`, config-vs-corpus doc (corpus PR #1). **Next: Group 4** (Installer Script) — `install.sh` is real **code** → goes `feat/* → PR → develop` in `agentic-ocean` (per the 2026-06-09 workflow correction). The mise entrypoint question (parked) attaches here.
+
+**Workflow (2026-06-09 correction):** dev-infra planning docs → `docs/skill-corpus-installation` branch → [PR #112](https://github.com/grimm00/dev-infra/pull/112); corpus code → `feat/* → PR → develop` in `agentic-ocean` (now default branch).
 
 **Cleanups done (2026-06-09):** `.dev-infra.yml` `version`/`created` placeholders filled in both repos (`0.11.0+nightly.88fc037`); `foobar` test command deleted from `~/.cursor/commands/` (now 21 = the migrated split). `expected_skills` kept as the core set — correct (those are the skills used when *working in* the repo). Remaining: `~/.cursor/` originals await the installer cutover (Groups 4–5).
 4. The symlink-vs-copy decision is settled (symlink primary) — Groups 3–4 assume symlink mode, copy-mode is the documented contingency.

--- a/admin/services/ai-workflow/features/skill-corpus-installation/planning/tasks/03-installer-mapping-and-xdg-config.md
+++ b/admin/services/ai-workflow/features/skill-corpus-installation/planning/tasks/03-installer-mapping-and-xdg-config.md
@@ -2,7 +2,8 @@
 
 **Feature:** Skill Corpus Installation (ADR-002)
 **Group:** Installer Mapping & XDG Config
-**Status:** 🟠 In Progress (Tasks 8–9 ✅; Task 10 — config-vs-corpus doc — remains)
+**Status:** ✅ Complete
+**Completed:** 2026-06-09
 **Last Updated:** 2026-06-09
 
 ---
@@ -130,7 +131,7 @@ config, corpus is a project; the installer bridges them.
 
 - [x] `installer.yaml` schema defined + documented (multi-source, per-item, collision=error, maps from `corpus/`) — `agentic-ocean/docs/installer-schema.md` + `installer.example.yaml` (`aec198d`)
 - [x] `~/.config/agentic-ocean/installer.yaml` established with both live sources (validated; roots resolve); `repos/` slot reserved; lookup order documented in the schema doc
-- [ ] Config-vs-corpus separation documented + cross-linked
+- [x] Config-vs-corpus separation documented + cross-linked — `agentic-ocean/docs/config-vs-corpus.md` (PR #1 → develop)
 
 ---
 


### PR DESCRIPTION
## Summary

Course-corrects the skill-corpus-installation workflow and becomes the home for the feature's **remaining** dev-infra planning updates (Task 10 + Groups 4–6 checkboxes) — landing them via a reviewable `docs/*` → develop PR instead of direct-to-develop.

- Adds int-opp: **feature-scale work bypassed PR via the docs-direct allowance** (the realization that drove this branch).
- Going forward, this branch accumulates the remaining planning-doc updates for the feature; merge to develop when Group 3–6 planning is done (or in sensible batches).

## Why

Groups 1–3's dev-infra side (all planning docs) was committed directly to develop — technically within the docs-direct allowance, but it bypassed the feat→PR→review/CI workflow the sibling `skill-template-separation` feature followed (PRs #106–#111). Can't rewrite the already-pushed develop history, so this corrects forward.

Separately corrected: the corpus repo `agentic-ocean` now has a `develop` branch (default) + feat→PR workflow, so Group 4's `install.sh` **code** gets reviewed.

## After Merge

- The int-opp proposes clarifying AGENTS.md (docs-direct = one-off fixes, not running a feature's planning tree) and a `/task` nudge onto a branch for feature-scale work.
- Remaining feature planning updates land here, not on develop directly.

## Follow-ups

- Corpus install code (`install.sh`, Group 4) → feat/* → PR in `agentic-ocean`.
- Personal corpus repo could adopt the same develop+feat workflow if/when it gains code.